### PR TITLE
Reverse the left/right terms in the diff

### DIFF
--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -363,7 +363,7 @@ func findAllRequestedSupportedTypes(supportedTypesWithGroups map[string][]string
 func (o *Options) Run() error {
 	showManagedFields := false
 
-	differ, err := diff.NewDiffer("LIVE", "MERGED")
+	differ, err := diff.NewDiffer("MERGED", "LIVE")
 	if err != nil {
 		return err
 	}

--- a/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/liveout.golden
+++ b/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/liveout.golden
@@ -5,23 +5,23 @@ diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEM
  kind: Deployment
  metadata:
    labels:
--    k8s-app: kubernetes-dashboard
--  name: kubernetes-dashboard
-+    k8s-app: dashboard-metrics-scraper
-+  name: dashboard-metrics-scraper
+-    k8s-app: dashboard-metrics-scraper
+-  name: dashboard-metrics-scraper
++    k8s-app: kubernetes-dashboard
++  name: kubernetes-dashboard
    namespace: kubernetes-dashboard
  spec:
    replicas: 1
    revisionHistoryLimit: 10
    selector:
      matchLabels:
--      k8s-app: kubernetes-dashboard
-+      k8s-app: dashboard-metrics-scraper
+-      k8s-app: dashboard-metrics-scraper
++      k8s-app: kubernetes-dashboard
    template:
      metadata:
        labels:
--        k8s-app: kubernetes-dashboard
-+        k8s-app: dashboard-metrics-scraper
+-        k8s-app: dashboard-metrics-scraper
++        k8s-app: kubernetes-dashboard
      spec:
        containers:
        - args:

--- a/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/localout.golden
+++ b/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/localout.golden
@@ -5,23 +5,23 @@ diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEM
  kind: Deployment
  metadata:
    labels:
--    k8s-app: kubernetes-dashboard
--  name: kubernetes-dashboard
-+    k8s-app: dashboard-metrics-scraper
-+  name: dashboard-metrics-scraper
+-    k8s-app: dashboard-metrics-scraper
+-  name: dashboard-metrics-scraper
++    k8s-app: kubernetes-dashboard
++  name: kubernetes-dashboard
    namespace: kubernetes-dashboard
  spec:
    replicas: 1
    revisionHistoryLimit: 10
    selector:
      matchLabels:
--      k8s-app: kubernetes-dashboard
-+      k8s-app: dashboard-metrics-scraper
+-      k8s-app: dashboard-metrics-scraper
++      k8s-app: kubernetes-dashboard
    template:
      metadata:
        labels:
--        k8s-app: kubernetes-dashboard
-+        k8s-app: dashboard-metrics-scraper
+-        k8s-app: dashboard-metrics-scraper
++        k8s-app: kubernetes-dashboard
      spec:
        containers:
        - args:

--- a/pkg/compare/testdata/ReffTemplateInSubDirNotReportedMissing/liveout.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirNotReportedMissing/liveout.golden
@@ -5,8 +5,8 @@ diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2
  kind: ConfigMap
  metadata:
    labels:
--    k8s-app: kubernetes-dashboard-diff
-+    k8s-app: kubernetes-dashboard
+-    k8s-app: kubernetes-dashboard
++    k8s-app: kubernetes-dashboard-diff
    name: kubernetes-dashboard-settings2
    namespace: kubernetes-dashboard
 

--- a/pkg/compare/testdata/ReffTemplateInSubDirNotReportedMissing/localout.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirNotReportedMissing/localout.golden
@@ -5,8 +5,8 @@ diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2
  kind: ConfigMap
  metadata:
    labels:
--    k8s-app: kubernetes-dashboard-diff
-+    k8s-app: kubernetes-dashboard
+-    k8s-app: kubernetes-dashboard
++    k8s-app: kubernetes-dashboard-diff
    name: kubernetes-dashboard-settings2
    namespace: kubernetes-dashboard
 

--- a/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/liveout.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/liveout.golden
@@ -5,23 +5,23 @@ diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEM
  kind: Deployment
  metadata:
    labels:
--    k8s-app: kubernetes-dashboard
--  name: kubernetes-dashboard
-+    k8s-app: dashboard-metrics-scraper
-+  name: dashboard-metrics-scraper
+-    k8s-app: dashboard-metrics-scraper
+-  name: dashboard-metrics-scraper
++    k8s-app: kubernetes-dashboard
++  name: kubernetes-dashboard
    namespace: kubernetes-dashboard
  spec:
    replicas: 1
    revisionHistoryLimit: 10
    selector:
      matchLabels:
--      k8s-app: kubernetes-dashboard
-+      k8s-app: dashboard-metrics-scraper
+-      k8s-app: dashboard-metrics-scraper
++      k8s-app: kubernetes-dashboard
    template:
      metadata:
        labels:
--        k8s-app: kubernetes-dashboard
-+        k8s-app: dashboard-metrics-scraper
+-        k8s-app: dashboard-metrics-scraper
++        k8s-app: kubernetes-dashboard
      spec:
        containers:
        - args:

--- a/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/localout.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/localout.golden
@@ -5,23 +5,23 @@ diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEM
  kind: Deployment
  metadata:
    labels:
--    k8s-app: kubernetes-dashboard
--  name: kubernetes-dashboard
-+    k8s-app: dashboard-metrics-scraper
-+  name: dashboard-metrics-scraper
+-    k8s-app: dashboard-metrics-scraper
+-  name: dashboard-metrics-scraper
++    k8s-app: kubernetes-dashboard
++  name: kubernetes-dashboard
    namespace: kubernetes-dashboard
  spec:
    replicas: 1
    revisionHistoryLimit: 10
    selector:
      matchLabels:
--      k8s-app: kubernetes-dashboard
-+      k8s-app: dashboard-metrics-scraper
+-      k8s-app: dashboard-metrics-scraper
++      k8s-app: kubernetes-dashboard
    template:
      metadata:
        labels:
--        k8s-app: kubernetes-dashboard
-+        k8s-app: dashboard-metrics-scraper
+-        k8s-app: dashboard-metrics-scraper
++        k8s-app: kubernetes-dashboard
      spec:
        containers:
        - args:

--- a/pkg/compare/testdata/ReffWithTemplateFunctionsRendersAsExpected/liveout.golden
+++ b/pkg/compare/testdata/ReffWithTemplateFunctionsRendersAsExpected/liveout.golden
@@ -5,8 +5,8 @@ diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings 
  kind: ConfigMap
  metadata:
    labels:
--    k8s-app: kubernetes-dashboard
-+    k8s-app: kubernetes-dashboardfunction was called successfully from different file
+-    k8s-app: kubernetes-dashboardfunction was called successfully from different file
++    k8s-app: kubernetes-dashboard
    name: kubernetes-dashboard-settings
    namespace: kubernetes-dashboard
 

--- a/pkg/compare/testdata/ReffWithTemplateFunctionsRendersAsExpected/localout.golden
+++ b/pkg/compare/testdata/ReffWithTemplateFunctionsRendersAsExpected/localout.golden
@@ -5,8 +5,8 @@ diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings 
  kind: ConfigMap
  metadata:
    labels:
--    k8s-app: kubernetes-dashboard
-+    k8s-app: kubernetes-dashboardfunction was called successfully from different file
+-    k8s-app: kubernetes-dashboardfunction was called successfully from different file
++    k8s-app: kubernetes-dashboard
    name: kubernetes-dashboard-settings
    namespace: kubernetes-dashboard
 


### PR DESCRIPTION
The reference configuration is the "baseline" and the live cluster is what is being validated. Reversing the order in the diff ensures that the + means "live cluster has this additional line" and - means "live cluster is missing this line"