### PR TITLE
Fix Misformatted Reference Configurations in Tests

### DIFF
--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/liveerr.golden
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/liveerr.golden
@@ -1,4 +1,0 @@
-error: an error occurred while parsing template: deploymentMetrics.yaml specified in the config. error: template: deploymentMetrics.yaml:19: unexpected {{end}}
-an error occurred while parsing template: secret.yaml specified in the config. error: template: secret.yaml:10: unexpected {{end}}
-an error occurred while parsing template: service.yaml specified in the config. error: template: service.yaml:13: unexpected {{end}} 
-error code:2

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/liveout.golden
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/liveout.golden
@@ -1,0 +1,4 @@
+
+Summary
+No CRs are missing
+No CRs are unmatched

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/localerr.golden
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/localerr.golden
@@ -1,4 +1,0 @@
-error: an error occurred while parsing template: deploymentMetrics.yaml specified in the config. error: template: deploymentMetrics.yaml:19: unexpected {{end}}
-an error occurred while parsing template: secret.yaml specified in the config. error: template: secret.yaml:10: unexpected {{end}}
-an error occurred while parsing template: service.yaml specified in the config. error: template: service.yaml:13: unexpected {{end}} 
-error code:2

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/localout.golden
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/localout.golden
@@ -1,0 +1,4 @@
+
+Summary
+No CRs are missing
+No CRs are unmatched

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/reference/deploymentMetrics.yaml
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/reference/deploymentMetrics.yaml
@@ -16,4 +16,4 @@ spec:
       labels:
         k8s-app: dashboard-metrics-scraper
     spec:
-  { { if .spec.template.spec } }{ { .spec.template.spec | toYaml | indent 5 } }{{end}}
+{{ if .spec.template.spec }}{{ .spec.template.spec | toYaml | indent 5 }}{{ end }}

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/reference/role.yaml
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/reference/role.yaml
@@ -1,10 +1,10 @@
 kind: Role
-apiVersion: { { .apiVersion } }
+apiVersion: {{ .apiVersion }}
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-  name: { { .metadata.name } }
-  namespace: { { .metadata.namespace } }
+  name: {{ .metadata.name }}
+  namespace: {{ .metadata.namespace }}
 rules:
   # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
   - apiGroups: [ "" ]

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/reference/sa.yaml
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/reference/sa.yaml
@@ -1,7 +1,7 @@
-apiVersion: { { .apiVersion } }
+apiVersion: {{ .apiVersion }}
 kind: ServiceAccount
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-  name: { { .metadata.name } }
+  name: {{ .metadata.name }}
   namespace: kubernetes-dashboard

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/reference/secret.yaml
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/reference/secret.yaml
@@ -3,8 +3,8 @@ kind: Secret
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-  name: { { .metadata.name } }
+  name: {{ .metadata.name }}
   namespace: kubernetes-dashboard
 type: Opaque
-  { { if .data } }data:
-  { { .data | toYaml } }{{end}}
+{{ if .data }}data:
+  {{ .data | toYaml }}{{ end }}

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/reference/service.yaml
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/reference/service.yaml
@@ -2,14 +2,14 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    k8s-app: {{if .metadata.labels}}{{ index .metadata.labels "k8s-app" }}{{end}}
-  name: { { .metadata.name } }
+    k8s-app: {{if .metadata.labels}}{{ index .metadata.labels "k8s-app" }}{{ end }}
+  name: {{ .metadata.name }}
   namespace: kubernetes-dashboard
 spec:
   ports:
-    { { - range .spec.ports } }
-    - port: { { .port } }
-      targetPort: { { .targetPort } }
-    {{end}}
+    {{- range .spec.ports }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort }}
+    {{ end }}
   selector:
-    k8s-app: {{if .spec.selector}}{{ index .spec.selector "k8s-app" }}{{end}}
+    k8s-app: {{if .spec.selector}}{{ index .spec.selector "k8s-app" }}{{ end }}

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/liveerr.golden
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/liveerr.golden
@@ -1,2 +1,0 @@
-error: an error occurred while parsing template: deploymentMetrics.yaml specified in the config. error: template: deploymentMetrics.yaml:19: unexpected {{end}} 
-error code:2

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/liveout.golden
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/liveout.golden
@@ -1,0 +1,4 @@
+
+Summary
+No CRs are missing
+No CRs are unmatched

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/localerr.golden
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/localerr.golden
@@ -1,2 +1,0 @@
-error: an error occurred while parsing template: deploymentMetrics.yaml specified in the config. error: template: deploymentMetrics.yaml:19: unexpected {{end}} 
-error code:2

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/localout.golden
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/localout.golden
@@ -1,0 +1,4 @@
+
+Summary
+No CRs are missing
+No CRs are unmatched

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/reference/deploymentMetrics.yaml
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/reference/deploymentMetrics.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 metadata:
   labels:
     k8s-app: dashboard-metrics-scraper
-  name: { { .metadata.name } }
+  name: {{ .metadata.name }}
   namespace: kubernetes-dashboard
 spec:
   replicas: 1
@@ -16,4 +16,4 @@ spec:
       labels:
         k8s-app: dashboard-metrics-scraper
     spec:
-  { { if .spec.template.spec } }{ { .spec.template.spec | toYaml | indent 5 } }{{end}}
+{{ if .spec.template.spec }}{{ .spec.template.spec | toYaml | indent 6 }}{{ end }}

--- a/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/liveerr.golden
+++ b/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/liveerr.golden
@@ -1,2 +1,2 @@
-error: an error occurred while parsing template: deploymentMetrics.yaml specified in the config. error: template: deploymentMetrics.yaml:19: unexpected {{end}} 
-error code:2
+ 
+error code:1

--- a/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/liveout.golden
+++ b/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/liveout.golden
@@ -1,0 +1,34 @@
+diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard
+--- TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
++++ TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
+@@ -2,19 +2,19 @@
+ kind: Deployment
+ metadata:
+   labels:
+-    k8s-app: kubernetes-dashboard
+-  name: kubernetes-dashboard
++    k8s-app: dashboard-metrics-scraper
++  name: dashboard-metrics-scraper
+   namespace: kubernetes-dashboard
+ spec:
+   replicas: 1
+   revisionHistoryLimit: 10
+   selector:
+     matchLabels:
+-      k8s-app: kubernetes-dashboard
++      k8s-app: dashboard-metrics-scraper
+   template:
+     metadata:
+       labels:
+-        k8s-app: kubernetes-dashboard
++        k8s-app: dashboard-metrics-scraper
+     spec:
+       containers:
+       - args:
+
+Summary
+Missing required CRs: 1 
+ExamplePart:
+  Dashboard:
+  - deploymentDashboard.yaml
+No CRs are unmatched

--- a/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/localerr.golden
+++ b/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/localerr.golden
@@ -1,2 +1,2 @@
-error: an error occurred while parsing template: deploymentMetrics.yaml specified in the config. error: template: deploymentMetrics.yaml:19: unexpected {{end}} 
-error code:2
+ 
+error code:1

--- a/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/localout.golden
+++ b/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/localout.golden
@@ -1,0 +1,34 @@
+diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard
+--- TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
++++ TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
+@@ -2,19 +2,19 @@
+ kind: Deployment
+ metadata:
+   labels:
+-    k8s-app: kubernetes-dashboard
+-  name: kubernetes-dashboard
++    k8s-app: dashboard-metrics-scraper
++  name: dashboard-metrics-scraper
+   namespace: kubernetes-dashboard
+ spec:
+   replicas: 1
+   revisionHistoryLimit: 10
+   selector:
+     matchLabels:
+-      k8s-app: kubernetes-dashboard
++      k8s-app: dashboard-metrics-scraper
+   template:
+     metadata:
+       labels:
+-        k8s-app: kubernetes-dashboard
++        k8s-app: dashboard-metrics-scraper
+     spec:
+       containers:
+       - args:
+
+Summary
+Missing required CRs: 1 
+ExamplePart:
+  Dashboard:
+  - deploymentDashboard.yaml
+No CRs are unmatched

--- a/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/reference/deploymentMetrics.yaml
+++ b/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/reference/deploymentMetrics.yaml
@@ -16,4 +16,4 @@ spec:
       labels:
         k8s-app: dashboard-metrics-scraper
     spec:
-  { { if .spec.template.spec } }{ { .spec.template.spec | toYaml | indent 5 } }{{end}}
+{{ if .spec.template.spec }}{{ .spec.template.spec | toYaml | indent 6 }}{{ end }}

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/liveerr.golden
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/liveerr.golden
@@ -1,4 +1,0 @@
-error: an error occurred while parsing template: secret.yaml specified in the config. error: template: secret.yaml:10: unexpected {{end}}
-an error occurred while parsing template: service.yaml specified in the config. error: template: service.yaml:13: unexpected {{end}}
-an error occurred while parsing template: deploymentMetrics.yaml specified in the config. error: template: deploymentMetrics.yaml:19: unexpected {{end}} 
-error code:2

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/liveout.golden
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/liveout.golden
@@ -1,0 +1,16 @@
+Reference Contains Templates With Types (kind) Not Supported By Cluster: ClusterRole, ClusterRoleBinding, ConfigMap, Deployment, Role, RoleBinding, Secret, Service, ServiceAccount
+
+Summary
+Missing required CRs: 5 
+ExamplePart1:
+  Dashboard1:
+  - cm.yaml
+  Dashboard2:
+  - deploymentDashboard.yaml
+  - deploymentMetrics.yaml
+ExamplePart2:
+  Dashboard1:
+  - cr.yaml
+  Dashboard2:
+  - crb.yaml
+No CRs are unmatched

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/localerr.golden
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/localerr.golden
@@ -1,4 +1,0 @@
-error: an error occurred while parsing template: secret.yaml specified in the config. error: template: secret.yaml:10: unexpected {{end}}
-an error occurred while parsing template: service.yaml specified in the config. error: template: service.yaml:13: unexpected {{end}}
-an error occurred while parsing template: deploymentMetrics.yaml specified in the config. error: template: deploymentMetrics.yaml:19: unexpected {{end}} 
-error code:2

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/localout.golden
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/localout.golden
@@ -1,0 +1,15 @@
+
+Summary
+Missing required CRs: 5 
+ExamplePart1:
+  Dashboard1:
+  - cm.yaml
+  Dashboard2:
+  - deploymentDashboard.yaml
+  - deploymentMetrics.yaml
+ExamplePart2:
+  Dashboard1:
+  - cr.yaml
+  Dashboard2:
+  - crb.yaml
+No CRs are unmatched

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/reference/deploymentMetrics.yaml
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/reference/deploymentMetrics.yaml
@@ -16,4 +16,4 @@ spec:
       labels:
         k8s-app: dashboard-metrics-scraper
     spec:
-  { { if .spec.template.spec } }{ { .spec.template.spec | toYaml | indent 5 } }{{end}}
+{{ if .spec.template.spec }}{{ .spec.template.spec | toYaml | indent 6 }}{{ end }}

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/reference/role.yaml
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/reference/role.yaml
@@ -1,10 +1,10 @@
 kind: Role
-apiVersion: { { .apiVersion } }
+apiVersion: {{ .apiVersion }}
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-  name: { { .metadata.name } }
-  namespace: { { .metadata.namespace } }
+  name: {{ .metadata.name }}
+  namespace: {{ .metadata.namespace }}
 rules:
   # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
   - apiGroups: [ "" ]

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/reference/sa.yaml
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/reference/sa.yaml
@@ -1,7 +1,7 @@
-apiVersion: { { .apiVersion } }
+apiVersion: {{ .apiVersion }}
 kind: ServiceAccount
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-  name: { { .metadata.name } }
+  name: {{ .metadata.name }}
   namespace: kubernetes-dashboard

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/reference/secret.yaml
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/reference/secret.yaml
@@ -3,8 +3,8 @@ kind: Secret
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-  name: { { .metadata.name } }
+  name: {{ .metadata.name }}
   namespace: kubernetes-dashboard
 type: Opaque
-  { { if .data } }data:
-  { { .data | toYaml } }{{end}}
+  {{ if .data }}data:
+  {{ .data | toYaml }}{{ end }}

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/reference/service.yaml
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/reference/service.yaml
@@ -2,14 +2,14 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    k8s-app: {{if .metadata.labels}}{{ index .metadata.labels "k8s-app" }}{{end}}
-  name: { { .metadata.name } }
+    k8s-app: {{if .metadata.labels}}{{ index .metadata.labels "k8s-app" }}{{ end }}
+  name: {{ .metadata.name }}
   namespace: kubernetes-dashboard
 spec:
   ports:
-    { { - range .spec.ports } }
-    - port: { { .port } }
-      targetPort: { { .targetPort } }
-    {{end}}
+    {{- range .spec.ports }}
+  - port: {{ .port }}
+    targetPort: {{ .targetPort }}
+    {{ end }}
   selector:
-    k8s-app: {{if .spec.selector}}{{ index .spec.selector "k8s-app" }}{{end}}
+    k8s-app: {{if .spec.selector}}{{ index .spec.selector "k8s-app" }}{{ end }}

--- a/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/liveerr.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/liveerr.golden
@@ -1,2 +1,2 @@
-error: an error occurred while parsing template: dir/deploymentMetrics.yaml specified in the config. error: template: deploymentMetrics.yaml:19: unexpected {{end}} 
-error code:2
+ 
+error code:1

--- a/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/liveout.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/liveout.golden
@@ -1,0 +1,31 @@
+diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard
+--- TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
++++ TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
+@@ -2,19 +2,19 @@
+ kind: Deployment
+ metadata:
+   labels:
+-    k8s-app: kubernetes-dashboard
+-  name: kubernetes-dashboard
++    k8s-app: dashboard-metrics-scraper
++  name: dashboard-metrics-scraper
+   namespace: kubernetes-dashboard
+ spec:
+   replicas: 1
+   revisionHistoryLimit: 10
+   selector:
+     matchLabels:
+-      k8s-app: kubernetes-dashboard
++      k8s-app: dashboard-metrics-scraper
+   template:
+     metadata:
+       labels:
+-        k8s-app: kubernetes-dashboard
++        k8s-app: dashboard-metrics-scraper
+     spec:
+       containers:
+       - args:
+
+Summary
+No CRs are missing
+No CRs are unmatched

--- a/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/localerr.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/localerr.golden
@@ -1,2 +1,2 @@
-error: an error occurred while parsing template: dir/deploymentMetrics.yaml specified in the config. error: template: deploymentMetrics.yaml:19: unexpected {{end}} 
-error code:2
+ 
+error code:1

--- a/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/localout.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/localout.golden
@@ -1,0 +1,31 @@
+diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard
+--- TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
++++ TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
+@@ -2,19 +2,19 @@
+ kind: Deployment
+ metadata:
+   labels:
+-    k8s-app: kubernetes-dashboard
+-  name: kubernetes-dashboard
++    k8s-app: dashboard-metrics-scraper
++  name: dashboard-metrics-scraper
+   namespace: kubernetes-dashboard
+ spec:
+   replicas: 1
+   revisionHistoryLimit: 10
+   selector:
+     matchLabels:
+-      k8s-app: kubernetes-dashboard
++      k8s-app: dashboard-metrics-scraper
+   template:
+     metadata:
+       labels:
+-        k8s-app: kubernetes-dashboard
++        k8s-app: dashboard-metrics-scraper
+     spec:
+       containers:
+       - args:
+
+Summary
+No CRs are missing
+No CRs are unmatched

--- a/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/reference/dir/deploymentMetrics.yaml
+++ b/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/reference/dir/deploymentMetrics.yaml
@@ -16,4 +16,4 @@ spec:
       labels:
         k8s-app: dashboard-metrics-scraper
     spec:
-  { { if .spec.template.spec } }{ { .spec.template.spec | toYaml | indent 5 } }{{end}}
+{{ if .spec.template.spec }}{{ .spec.template.spec | toYaml | indent 6 }}{{end}}

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/liveerr.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/liveerr.golden
@@ -1,4 +1,0 @@
-error: an error occurred while parsing template: secret.yaml specified in the config. error: template: secret.yaml:10: unexpected {{end}}
-an error occurred while parsing template: service.yaml specified in the config. error: template: service.yaml:13: unexpected {{end}}
-an error occurred while parsing template: deploymentMetrics.yaml specified in the config. error: template: deploymentMetrics.yaml:19: unexpected {{end}} 
-error code:2

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/liveout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/liveout.golden
@@ -1,0 +1,5 @@
+Reference Contains Templates With Types (kind) Not Supported By Cluster: ClusterRole, ClusterRoleBinding, ConfigMap, Deployment, Role, RoleBinding, Secret, Service, ServiceAccount
+
+Summary
+No CRs are missing
+No CRs are unmatched

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/localerr.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/localerr.golden
@@ -1,4 +1,0 @@
-error: an error occurred while parsing template: secret.yaml specified in the config. error: template: secret.yaml:10: unexpected {{end}}
-an error occurred while parsing template: service.yaml specified in the config. error: template: service.yaml:13: unexpected {{end}}
-an error occurred while parsing template: deploymentMetrics.yaml specified in the config. error: template: deploymentMetrics.yaml:19: unexpected {{end}} 
-error code:2

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/localout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/localout.golden
@@ -1,0 +1,4 @@
+
+Summary
+No CRs are missing
+No CRs are unmatched

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/reference/deploymentMetrics.yaml
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/reference/deploymentMetrics.yaml
@@ -16,4 +16,4 @@ spec:
       labels:
         k8s-app: dashboard-metrics-scraper
     spec:
-  { { if .spec.template.spec } }{ { .spec.template.spec | toYaml | indent 5 } }{{end}}
+{{ if .spec.template.spec }}{{ .spec.template.spec | toYaml | indent 6 }}{{end}}

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/reference/role.yaml
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/reference/role.yaml
@@ -1,10 +1,10 @@
 kind: Role
-apiVersion: { { .apiVersion } }
+apiVersion: {{ .apiVersion }}
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-  name: { { .metadata.name } }
-  namespace: { { .metadata.namespace } }
+  name: {{ .metadata.name }}
+  namespace: {{ .metadata.namespace }}
 rules:
   # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
   - apiGroups: [ "" ]

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/reference/sa.yaml
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/reference/sa.yaml
@@ -1,7 +1,7 @@
-apiVersion: { { .apiVersion } }
+apiVersion: {{ .apiVersion }}
 kind: ServiceAccount
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-  name: { { .metadata.name } }
+  name: {{ .metadata.name }}
   namespace: kubernetes-dashboard

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/reference/secret.yaml
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/reference/secret.yaml
@@ -3,8 +3,8 @@ kind: Secret
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-  name: { { .metadata.name } }
+  name: {{ .metadata.name }}
   namespace: kubernetes-dashboard
 type: Opaque
-  { { if .data } }data:
-  { { .data | toYaml } }{{end}}
+  {{ if .data }}data:
+  {{ .data | toYaml }}{{end}}

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/reference/service.yaml
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/reference/service.yaml
@@ -3,13 +3,13 @@ apiVersion: v1
 metadata:
   labels:
     k8s-app: {{if .metadata.labels}}{{ index .metadata.labels "k8s-app" }}{{end}}
-  name: { { .metadata.name } }
+  name: {{ .metadata.name }}
   namespace: kubernetes-dashboard
 spec:
   ports:
-    { { - range .spec.ports } }
-    - port: { { .port } }
-      targetPort: { { .targetPort } }
+    {{- range .spec.ports }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort }}
     {{end}}
   selector:
     k8s-app: {{if .spec.selector}}{{ index .spec.selector "k8s-app" }}{{end}}

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/liveerr.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/liveerr.golden
@@ -1,4 +1,0 @@
-error: an error occurred while parsing template: secret.yaml specified in the config. error: template: secret.yaml:10: unexpected {{end}}
-an error occurred while parsing template: service.yaml specified in the config. error: template: service.yaml:13: unexpected {{end}}
-an error occurred while parsing template: deploymentMetrics.yaml specified in the config. error: template: deploymentMetrics.yaml:19: unexpected {{end}} 
-error code:2

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/liveout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/liveout.golden
@@ -1,0 +1,8 @@
+Reference Contains Templates With Types (kind) Not Supported By Cluster: ClusterRole, ClusterRoleBinding, ConfigMap, Deployment, Role, RoleBinding, Secret, Service, ServiceAccount
+
+Summary
+Missing required CRs: 1 
+ExamplePart1:
+  Dashboard1:
+  - cm.yaml
+No CRs are unmatched

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/localerr.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/localerr.golden
@@ -1,4 +1,0 @@
-error: an error occurred while parsing template: secret.yaml specified in the config. error: template: secret.yaml:10: unexpected {{end}}
-an error occurred while parsing template: service.yaml specified in the config. error: template: service.yaml:13: unexpected {{end}}
-an error occurred while parsing template: deploymentMetrics.yaml specified in the config. error: template: deploymentMetrics.yaml:19: unexpected {{end}} 
-error code:2

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/localout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/localout.golden
@@ -1,0 +1,7 @@
+
+Summary
+Missing required CRs: 1 
+ExamplePart1:
+  Dashboard1:
+  - cm.yaml
+No CRs are unmatched

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/reference/deploymentMetrics.yaml
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/reference/deploymentMetrics.yaml
@@ -16,4 +16,4 @@ spec:
       labels:
         k8s-app: dashboard-metrics-scraper
     spec:
-  { { if .spec.template.spec } }{ { .spec.template.spec | toYaml | indent 5 } }{{end}}
+{{ if .spec.template.spec }}{{ .spec.template.spec | toYaml | indent 6 }}{{end}}

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/reference/role.yaml
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/reference/role.yaml
@@ -1,10 +1,10 @@
 kind: Role
-apiVersion: { { .apiVersion } }
+apiVersion: {{ .apiVersion }}
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-  name: { { .metadata.name } }
-  namespace: { { .metadata.namespace } }
+  name: {{ .metadata.name }}
+  namespace: {{ .metadata.namespace }}
 rules:
   # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
   - apiGroups: [ "" ]

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/reference/sa.yaml
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/reference/sa.yaml
@@ -1,7 +1,7 @@
-apiVersion: { { .apiVersion } }
+apiVersion: {{ .apiVersion }}
 kind: ServiceAccount
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-  name: { { .metadata.name } }
+  name: {{ .metadata.name }}
   namespace: kubernetes-dashboard

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/reference/secret.yaml
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/reference/secret.yaml
@@ -3,8 +3,8 @@ kind: Secret
 metadata:
   labels:
     k8s-app: kubernetes-dashboard
-  name: { { .metadata.name } }
+  name: {{ .metadata.name }}
   namespace: kubernetes-dashboard
 type: Opaque
-  { { if .data } }data:
-  { { .data | toYaml } }{{end}}
+  {{ if .data }}data:
+  {{ .data | toYaml }}{{end}}

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/reference/service.yaml
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/reference/service.yaml
@@ -3,13 +3,13 @@ apiVersion: v1
 metadata:
   labels:
     k8s-app: {{if .metadata.labels}}{{ index .metadata.labels "k8s-app" }}{{end}}
-  name: { { .metadata.name } }
+  name: {{ .metadata.name }}
   namespace: kubernetes-dashboard
 spec:
   ports:
-    { { - range .spec.ports } }
-    - port: { { .port } }
-      targetPort: { { .targetPort } }
+    {{- range .spec.ports }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort }}
     {{end}}
   selector:
     k8s-app: {{if .spec.selector}}{{ index .spec.selector "k8s-app" }}{{end}}

--- a/pkg/compare/testdata/TemplateIsntYAMLAfterExecutionWithEmptyMap/localerr.golden
+++ b/pkg/compare/testdata/TemplateIsntYAMLAfterExecutionWithEmptyMap/localerr.golden
@@ -1,2 +1,2 @@
-error: an error occurred while parsing template: apps.v1.DaemonSet.kube-system.kindnet.yaml specified in the config. error: template: apps.v1.DaemonSet.kube-system.kindnet.yaml:5: unexpected {{end}} 
+error: template: apps.v1.DaemonSet.kube-system.kindnet.yaml:5:61: executing "apps.v1.DaemonSet.kube-system.kindnet.yaml" at <len .spec.annotations>: error calling len: reflect: call of reflect.Value.Type on zero Value 
 error code:2

--- a/pkg/compare/testdata/TemplateIsntYAMLAfterExecutionWithEmptyMap/reference/apps.v1.DaemonSet.kube-system.kindnet.yaml
+++ b/pkg/compare/testdata/TemplateIsntYAMLAfterExecutionWithEmptyMap/reference/apps.v1.DaemonSet.kube-system.kindnet.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    deprecated.daemonset.template.generation: "1" { { - if ne (len .spec.annotations) 1 } } Sorry. cant have more than one entry {{- end }}
+    deprecated.daemonset.template.generation: "1" {{- if ne (len .spec.annotations) 1 }} Sorry. cant have more than one entry {{- end }}
   generation: 1
   labels:
     app: kindnet


### PR DESCRIPTION
Fixed multiple tests where the reference config used by the tests was misformatted, and now it correctly follows templating syntax. Most of the mistakes were in curly brackets that were separated by spaces instead of being without spaces. After this fix, the tests should accurately validate the expected behavior.