### PR TITLE
Converted to Separate Execution of Diff Command for Each CR

### DIFF
--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/liveout.golden
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/liveout.golden
@@ -1,4 +1,91 @@
 
+**********************************
+
+Cluster CR: v1_ConfigMap_kubernetes-dashboard_kubernetes-dashboard-settings
+Reference File: cm.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: rbac.authorization.k8s.io/v1_ClusterRole_kubernetes-dashboard
+Reference File: cr.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: rbac.authorization.k8s.io/v1_ClusterRoleBinding_kubernetes-dashboard
+Reference File: crb.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
+Reference File: deploymentDashboard.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
+Reference File: deploymentMetrics.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Namespace_kubernetes-dashboard
+Reference File: ns.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Namespace_kubernetes-dashboard
+Reference File: ns.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: rbac.authorization.k8s.io/v1_RoleBinding_kubernetes-dashboard_kubernetes-dashboard
+Reference File: rb.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: rbac.authorization.k8s.io/v1_Role_kubernetes-dashboard_kubernetes-dashboard
+Reference File: role.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_ServiceAccount_kubernetes-dashboard_kubernetes-dashboard
+Reference File: sa.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Secret_kubernetes-dashboard_kubernetes-dashboard-certs
+Reference File: secret.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Secret_kubernetes-dashboard_kubernetes-dashboard-csrf
+Reference File: secret.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Secret_kubernetes-dashboard_kubernetes-dashboard-key-holder
+Reference File: secret.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Service_kubernetes-dashboard_kubernetes-dashboard
+Reference File: service.yaml
+Diff Output: None
+
+**********************************
+
 Summary
-No CRs are missing
-No CRs are unmatched
+CRs with diffs: 0
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/localout.golden
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/localout.golden
@@ -1,4 +1,169 @@
 
+**********************************
+
+Cluster CR: v1_ConfigMap_kubernetes-dashboard_kubernetes-dashboard-settings
+Reference File: cm.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_ConfigMap_kubernetes-dashboard_kubernetes-dashboard-settings
+Reference File: cm.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: rbac.authorization.k8s.io/v1_ClusterRole_kubernetes-dashboard
+Reference File: cr.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: rbac.authorization.k8s.io/v1_ClusterRole_kubernetes-dashboard
+Reference File: cr.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: rbac.authorization.k8s.io/v1_ClusterRoleBinding_kubernetes-dashboard
+Reference File: crb.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: rbac.authorization.k8s.io/v1_ClusterRoleBinding_kubernetes-dashboard
+Reference File: crb.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
+Reference File: deploymentDashboard.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
+Reference File: deploymentDashboard.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
+Reference File: deploymentMetrics.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
+Reference File: deploymentMetrics.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Namespace_kubernetes-dashboard
+Reference File: ns.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Namespace_kubernetes-dashboard
+Reference File: ns.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: rbac.authorization.k8s.io/v1_RoleBinding_kubernetes-dashboard_kubernetes-dashboard
+Reference File: rb.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: rbac.authorization.k8s.io/v1_RoleBinding_kubernetes-dashboard_kubernetes-dashboard
+Reference File: rb.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: rbac.authorization.k8s.io/v1_Role_kubernetes-dashboard_kubernetes-dashboard
+Reference File: role.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: rbac.authorization.k8s.io/v1_Role_kubernetes-dashboard_kubernetes-dashboard
+Reference File: role.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_ServiceAccount_kubernetes-dashboard_kubernetes-dashboard
+Reference File: sa.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_ServiceAccount_kubernetes-dashboard_kubernetes-dashboard
+Reference File: sa.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Secret_kubernetes-dashboard_kubernetes-dashboard-certs
+Reference File: secret.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Secret_kubernetes-dashboard_kubernetes-dashboard-certs
+Reference File: secret.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Secret_kubernetes-dashboard_kubernetes-dashboard-csrf
+Reference File: secret.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Secret_kubernetes-dashboard_kubernetes-dashboard-csrf
+Reference File: secret.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Secret_kubernetes-dashboard_kubernetes-dashboard-key-holder
+Reference File: secret.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Secret_kubernetes-dashboard_kubernetes-dashboard-key-holder
+Reference File: secret.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Service_kubernetes-dashboard_dashboard-metrics-scraper
+Reference File: service.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Service_kubernetes-dashboard_kubernetes-dashboard
+Reference File: service.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: v1_Service_kubernetes-dashboard_kubernetes-dashboard
+Reference File: service.yaml
+Diff Output: None
+
+**********************************
+
 Summary
-No CRs are missing
-No CRs are unmatched
+CRs with diffs: 0
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/liveout.golden
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/liveout.golden
@@ -1,4 +1,25 @@
 
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
+Reference File: deploymentMetrics.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
+Reference File: deploymentMetrics.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
+Reference File: deploymentMetrics.yaml
+Diff Output: None
+
+**********************************
+
 Summary
-No CRs are missing
-No CRs are unmatched
+CRs with diffs: 0
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/localout.golden
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/localout.golden
@@ -1,4 +1,25 @@
 
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
+Reference File: deploymentMetrics.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
+Reference File: deploymentMetrics.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
+Reference File: deploymentMetrics.yaml
+Diff Output: None
+
+**********************************
+
 Summary
-No CRs are missing
-No CRs are unmatched
+CRs with diffs: 0
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/liveout.golden
+++ b/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/liveout.golden
@@ -1,4 +1,15 @@
-diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
+Reference File: deploymentMetrics.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
+Reference File: deploymentMetrics.yaml
+Diff Output: diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard
 --- TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
 +++ TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
 @@ -2,19 +2,19 @@
@@ -26,9 +37,12 @@ diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEM
        containers:
        - args:
 
+**********************************
+
 Summary
-Missing required CRs: 1 
+CRs with diffs: 1
+CRs in reference missing from the cluster: 1 
 ExamplePart:
   Dashboard:
   - deploymentDashboard.yaml
-No CRs are unmatched
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/localout.golden
+++ b/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/localout.golden
@@ -1,4 +1,15 @@
-diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
+Reference File: deploymentMetrics.yaml
+Diff Output: None
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
+Reference File: deploymentMetrics.yaml
+Diff Output: diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard
 --- TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
 +++ TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
 @@ -2,19 +2,19 @@
@@ -26,9 +37,12 @@ diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEM
        containers:
        - args:
 
+**********************************
+
 Summary
-Missing required CRs: 1 
+CRs with diffs: 1
+CRs in reference missing from the cluster: 1 
 ExamplePart:
   Dashboard:
   - deploymentDashboard.yaml
-No CRs are unmatched
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/liveerr.golden
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/liveerr.golden
@@ -1,0 +1,2 @@
+ 
+error code:1

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/liveout.golden
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/liveout.golden
@@ -1,7 +1,16 @@
 Reference Contains Templates With Types (kind) Not Supported By Cluster: ClusterRole, ClusterRoleBinding, ConfigMap, Deployment, Role, RoleBinding, Secret, Service, ServiceAccount
 
+**********************************
+
+Cluster CR: v1_Namespace_kubernetes-dashboard
+Reference File: ns.yaml
+Diff Output: None
+
+**********************************
+
 Summary
-Missing required CRs: 5 
+CRs with diffs: 0
+CRs in reference missing from the cluster: 5 
 ExamplePart1:
   Dashboard1:
   - cm.yaml
@@ -13,4 +22,4 @@ ExamplePart2:
   - cr.yaml
   Dashboard2:
   - crb.yaml
-No CRs are unmatched
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/localerr.golden
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/localerr.golden
@@ -1,0 +1,2 @@
+ 
+error code:1

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/localout.golden
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/localout.golden
@@ -1,6 +1,15 @@
 
+**********************************
+
+Cluster CR: v1_Namespace_kubernetes-dashboard
+Reference File: ns.yaml
+Diff Output: None
+
+**********************************
+
 Summary
-Missing required CRs: 5 
+CRs with diffs: 0
+CRs in reference missing from the cluster: 5 
 ExamplePart1:
   Dashboard1:
   - cm.yaml
@@ -12,4 +21,4 @@ ExamplePart2:
   - cr.yaml
   Dashboard2:
   - crb.yaml
-No CRs are unmatched
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/OnlyResourcesThatWereNotMatchedBecauseMultipleMatchesAppearInSummary/localerr.golden
+++ b/pkg/compare/testdata/OnlyResourcesThatWereNotMatchedBecauseMultipleMatchesAppearInSummary/localerr.golden
@@ -1,0 +1,2 @@
+ 
+error code:1

--- a/pkg/compare/testdata/OnlyResourcesThatWereNotMatchedBecauseMultipleMatchesAppearInSummary/localout.golden
+++ b/pkg/compare/testdata/OnlyResourcesThatWereNotMatchedBecauseMultipleMatchesAppearInSummary/localout.golden
@@ -1,11 +1,14 @@
 More then one template with same apiVersion, metadata_namespace, kind. These templates wont be used for corelation. To use them use different corelator (manual matching) or remove one of them from the reference.  Template names are: apps.v1.DaemonSet.kube-system.kindnet.yaml, apps.v1.DaemonSet.kube-system.kindnet2.yaml
 
+**********************************
+
 Summary
-Missing required CRs: 1 
+CRs with diffs: 0
+CRs in reference missing from the cluster: 1 
 ExamplePart:
   DemonSets:
   - apps.v1.DaemonSet.kube-system.kindnet.yaml
-CRs are unmatched: 3
+Cluster CRs unmatched to reference CRs: 3
 - apps/v1_DaemonSet_SomeNS_Test1
 - apps/v1_DaemonSet_SomeNS_Test2
 - apps/v1_DaemonSet_SomeNS_Name

--- a/pkg/compare/testdata/ReffTemplateInSubDirNotReportedMissing/liveout.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirNotReportedMissing/liveout.golden
@@ -1,4 +1,9 @@
-diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2 TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2
+
+**********************************
+
+Cluster CR: v1_ConfigMap_kubernetes-dashboard_kubernetes-dashboard-settings2
+Reference File: a/g.yaml
+Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2 TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2
 --- TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2	DATE
 +++ TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2	DATE
 @@ -2,6 +2,6 @@
@@ -10,6 +15,9 @@ diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2
    name: kubernetes-dashboard-settings2
    namespace: kubernetes-dashboard
 
+**********************************
+
 Summary
-No CRs are missing
-No CRs are unmatched
+CRs with diffs: 1
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/ReffTemplateInSubDirNotReportedMissing/localout.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirNotReportedMissing/localout.golden
@@ -1,4 +1,9 @@
-diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2 TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2
+
+**********************************
+
+Cluster CR: v1_ConfigMap_kubernetes-dashboard_kubernetes-dashboard-settings2
+Reference File: a/g.yaml
+Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2 TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2
 --- TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2	DATE
 +++ TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2	DATE
 @@ -2,6 +2,6 @@
@@ -10,6 +15,9 @@ diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings2
    name: kubernetes-dashboard-settings2
    namespace: kubernetes-dashboard
 
+**********************************
+
 Summary
-No CRs are missing
-No CRs are unmatched
+CRs with diffs: 1
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/liveout.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/liveout.golden
@@ -1,4 +1,9 @@
-diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
+Reference File: dir/deploymentMetrics.yaml
+Diff Output: diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard
 --- TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
 +++ TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
 @@ -2,19 +2,19 @@
@@ -26,6 +31,9 @@ diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEM
        containers:
        - args:
 
+**********************************
+
 Summary
-No CRs are missing
-No CRs are unmatched
+CRs with diffs: 1
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/localout.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/localout.golden
@@ -1,4 +1,9 @@
-diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard
+
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
+Reference File: dir/deploymentMetrics.yaml
+Diff Output: diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard
 --- TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
 +++ TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard	DATE
 @@ -2,19 +2,19 @@
@@ -26,6 +31,9 @@ diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard TEM
        containers:
        - args:
 
+**********************************
+
 Summary
-No CRs are missing
-No CRs are unmatched
+CRs with diffs: 1
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/ReffWithTemplateFunctionsRendersAsExpected/liveout.golden
+++ b/pkg/compare/testdata/ReffWithTemplateFunctionsRendersAsExpected/liveout.golden
@@ -1,4 +1,9 @@
-diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings
+
+**********************************
+
+Cluster CR: v1_ConfigMap_kubernetes-dashboard_kubernetes-dashboard-settings
+Reference File: cm.yaml
+Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings
 --- TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings	DATE
 +++ TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings	DATE
 @@ -2,6 +2,6 @@
@@ -10,6 +15,9 @@ diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings 
    name: kubernetes-dashboard-settings
    namespace: kubernetes-dashboard
 
+**********************************
+
 Summary
-No CRs are missing
-No CRs are unmatched
+CRs with diffs: 1
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/ReffWithTemplateFunctionsRendersAsExpected/localout.golden
+++ b/pkg/compare/testdata/ReffWithTemplateFunctionsRendersAsExpected/localout.golden
@@ -1,4 +1,9 @@
-diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings
+
+**********************************
+
+Cluster CR: v1_ConfigMap_kubernetes-dashboard_kubernetes-dashboard-settings
+Reference File: cm.yaml
+Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings
 --- TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings	DATE
 +++ TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings	DATE
 @@ -2,6 +2,6 @@
@@ -10,6 +15,9 @@ diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings 
    name: kubernetes-dashboard-settings
    namespace: kubernetes-dashboard
 
+**********************************
+
 Summary
-No CRs are missing
-No CRs are unmatched
+CRs with diffs: 1
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/liveout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/liveout.golden
@@ -1,5 +1,14 @@
 Reference Contains Templates With Types (kind) Not Supported By Cluster: ClusterRole, ClusterRoleBinding, ConfigMap, Deployment, Role, RoleBinding, Secret, Service, ServiceAccount
 
+**********************************
+
+Cluster CR: v1_Namespace_kubernetes-dashboard
+Reference File: ns.yaml
+Diff Output: None
+
+**********************************
+
 Summary
-No CRs are missing
-No CRs are unmatched
+CRs with diffs: 0
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/localout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/localout.golden
@@ -1,4 +1,13 @@
 
+**********************************
+
+Cluster CR: v1_Namespace_kubernetes-dashboard
+Reference File: ns.yaml
+Diff Output: None
+
+**********************************
+
 Summary
-No CRs are missing
-No CRs are unmatched
+CRs with diffs: 0
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/liveerr.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/liveerr.golden
@@ -1,0 +1,2 @@
+ 
+error code:1

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/liveout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/liveout.golden
@@ -1,8 +1,17 @@
 Reference Contains Templates With Types (kind) Not Supported By Cluster: ClusterRole, ClusterRoleBinding, ConfigMap, Deployment, Role, RoleBinding, Secret, Service, ServiceAccount
 
+**********************************
+
+Cluster CR: v1_Namespace_kubernetes-dashboard
+Reference File: ns.yaml
+Diff Output: None
+
+**********************************
+
 Summary
-Missing required CRs: 1 
+CRs with diffs: 0
+CRs in reference missing from the cluster: 1 
 ExamplePart1:
   Dashboard1:
   - cm.yaml
-No CRs are unmatched
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/localerr.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/localerr.golden
@@ -1,0 +1,2 @@
+ 
+error code:1

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/localout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/localout.golden
@@ -1,7 +1,16 @@
 
+**********************************
+
+Cluster CR: v1_Namespace_kubernetes-dashboard
+Reference File: ns.yaml
+Diff Output: None
+
+**********************************
+
 Summary
-Missing required CRs: 1 
+CRs with diffs: 0
+CRs in reference missing from the cluster: 1 
 ExamplePart1:
   Dashboard1:
   - cm.yaml
-No CRs are unmatched
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/TemplatesContainKindThatIsNotRecognizableInLiveCluster/liveerr.golden
+++ b/pkg/compare/testdata/TemplatesContainKindThatIsNotRecognizableInLiveCluster/liveerr.golden
@@ -1,0 +1,2 @@
+ 
+error code:1

--- a/pkg/compare/testdata/TemplatesContainKindThatIsNotRecognizableInLiveCluster/liveout.golden
+++ b/pkg/compare/testdata/TemplatesContainKindThatIsNotRecognizableInLiveCluster/liveout.golden
@@ -1,8 +1,17 @@
 Reference Contains Templates With Types (kind) Not Supported By Cluster: KindNotSupportedByCluster
 
+**********************************
+
+Cluster CR: apps/v1_DaemonSet_
+Reference File: apps.v1.DaemonSet.kube-system.kindnet.yaml
+Diff Output: None
+
+**********************************
+
 Summary
-Missing required CRs: 1 
+CRs with diffs: 0
+CRs in reference missing from the cluster: 1 
 ExamplePart:
   DemonSets:
   - apps.v1.KindNotSupportedByCluster.kube-system.kindnet.yaml
-No CRs are unmatched
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localerr.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localerr.golden
@@ -1,0 +1,2 @@
+ 
+error code:1

--- a/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localout.golden
@@ -1,9 +1,12 @@
 More then one template with same apiVersion, metadata_namespace, kind. These templates wont be used for corelation. To use them use different corelator (manual matching) or remove one of them from the reference.  Template names are: apps.v1.DaemonSet.kube-system.kindnet.yaml, apps.v1.DaemonSet.kube-system.kindnet2.yaml
 
+**********************************
+
 Summary
-Missing required CRs: 1 
+CRs with diffs: 0
+CRs in reference missing from the cluster: 1 
 ExamplePart:
   DemonSets:
   - apps.v1.DaemonSet.kube-system.kindnet.yaml
-CRs are unmatched: 1
+Cluster CRs unmatched to reference CRs: 1
 - apps/v1_DaemonSet_SomeNS_Name

--- a/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localerr.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localerr.golden
@@ -1,0 +1,2 @@
+ 
+error code:1

--- a/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localout.golden
@@ -1,9 +1,12 @@
 More then one template with same apiVersion, metadata_name, metadata_namespace, kind. These templates wont be used for corelation. To use them use different corelator (manual matching) or remove one of them from the reference.  Template names are: apps.v1.DaemonSet.kube-system.kindnet.yaml, apps.v1.DaemonSet.kube-system.kindnet.yaml
 
+**********************************
+
 Summary
-Missing required CRs: 1 
+CRs with diffs: 0
+CRs in reference missing from the cluster: 1 
 ExamplePart:
   DemonSets:
   - apps.v1.DaemonSet.kube-system.kindnet.yaml
-CRs are unmatched: 1
+Cluster CRs unmatched to reference CRs: 1
 - apps/v1_DaemonSet_SomeNS_Name

--- a/pkg/compare/testdata/WhenUsingDiffAllFlag-AllUnmatchedResourcesAppearInSummary/localerr.golden
+++ b/pkg/compare/testdata/WhenUsingDiffAllFlag-AllUnmatchedResourcesAppearInSummary/localerr.golden
@@ -1,0 +1,2 @@
+ 
+error code:1

--- a/pkg/compare/testdata/WhenUsingDiffAllFlag-AllUnmatchedResourcesAppearInSummary/localout.golden
+++ b/pkg/compare/testdata/WhenUsingDiffAllFlag-AllUnmatchedResourcesAppearInSummary/localout.golden
@@ -1,11 +1,14 @@
 More then one template with same apiVersion, metadata_namespace, kind. These templates wont be used for corelation. To use them use different corelator (manual matching) or remove one of them from the reference.  Template names are: apps.v1.DaemonSet.kube-system.kindnet.yaml, apps.v1.DaemonSet.kube-system.kindnet2.yaml
 
+**********************************
+
 Summary
-Missing required CRs: 1 
+CRs with diffs: 0
+CRs in reference missing from the cluster: 1 
 ExamplePart:
   DemonSets:
   - apps.v1.DaemonSet.kube-system.kindnet.yaml
-CRs are unmatched: 30
+Cluster CRs unmatched to reference CRs: 30
 - apps/v1_DaemonSet_SomeNS_Test1
 - apps/v1_DaemonSet_SomeNS_Test2
 - v1_ConfigMap_kubernetes-dashboard_kubernetes-dashboard-settings


### PR DESCRIPTION
This commit changes the run behavior of the diff command to execute separately for each CR instead of running the diff command once for all CRs. This change enables easy tracking of the number of CRs containing differences, and they are now added to the command output. Additionally, this change generates separate output for each CR, enabling the addition of additional information to each presented diff. For each found diff, the CR name and its correlated matching template name are now presented. Furthermore, a separator string has been added between each diff to allow clearer separation between CRs diff outputs. Also, the titles of the command summary output have been changed to be more informative.