### PR TITLE
Add release endpoint to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Dockerfile.cross
 
 #macOS
 .DS_Store
+
+# Release artifacts
+dist/*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,29 @@
+project_name: kube-compare
+release:
+  github:
+    owner: openshift
+    name: kube-compare
+builds:
+  - id: kube-compare
+    binary: kubectl-cluster_compare
+    goos:
+    - linux
+    - windows
+    - darwin
+    goarch:
+    - amd64
+    - "386"
+    env:
+      - CGO_ENABLED=0
+      - GO111MODULE=on
+    main: cmd/kubectl-cluster_compare.go
+    ldflags: -s -w
+      -X github.com/openshift/kube-compare/pkg/version.version=
+archives:
+  - id: kube-compare
+    builds:
+    - kube-compare
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+    - goos: windows
+      format: zip

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -1,0 +1,17 @@
+# Release Guide
+
+The plugin uses GitHub releases to store binaries and release info. The release notes and binaries are created using
+GoReleaser allowing to build the binary for different architectures and platforms. The configuration of GoReleaser
+is located in .goreleaser.yml.
+
+## Release instructions
+
+1. In your local clone of the project tag the commit using git, the tags value should be the number of the release
+   formatted as "v[major].[minor].[tiny]". for example "v1.0.0".
+2. Run `make release-dry-run`, The release files will be created in the dist directory. make sure the release contains
+   the expected changes. once you are satisfied continue to the next step.
+3. Set GITHUB_TOKEN environment variable to be your GitHub api token, the minimum permissions needed are
+   `packages:write`. (run `export GITHUB_TOKEN="<YOUR_TOKEN>"`).
+4. Run `make release`, the command should upload the release to GitHub.
+
+The release notes can be edited manually at any time if needed [here](https://github.com/openshift/kube-compare/releases).


### PR DESCRIPTION
This commit adds the `release` and `release-dry-run` endpoints to the Makefile. These endpoints use Goreleaser to build the compare binary for different architectures and platforms. The `release-dry-run` endpoint only builds the binaries, creates the archives, and generates the release notes. The `release` endpoint also uploads the release to GitHub. The release notes contain a list of all the changes from the previous tag to the newest tag.