### PR TITLE
Change command behavior to skip invalid resources in local mode

### DIFF
--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -399,6 +399,11 @@ error code:2`),
 			checks:        defaultChecks.withPrefixedSuffix("withVebosityFlag"),
 			verboseOutput: true,
 		},
+		{
+			mode:   []Mode{{Local, LocalRef}},
+			name:   "Invalid Resources Are Skipped",
+			checks: defaultChecks,
+		},
 	}
 	tf := cmdtesting.NewTestFactory()
 	testFlags := flag.NewFlagSet("test", flag.ContinueOnError)

--- a/pkg/compare/testdata/InvalidResourcesAreSkipped/localerr.golden
+++ b/pkg/compare/testdata/InvalidResourcesAreSkipped/localerr.golden
@@ -1,0 +1,2 @@
+
+error code:1

--- a/pkg/compare/testdata/InvalidResourcesAreSkipped/localout.golden
+++ b/pkg/compare/testdata/InvalidResourcesAreSkipped/localout.golden
@@ -1,0 +1,32 @@
+Skipping "testdata/InvalidResourcesAreSkipped/resources/d1.json": Input contains additional files from supported file extensions (json/yaml) that do not contain a valid resource, error: 'Kind' is missing.
+ In case this file is expected to be a valid resource modify it accordingly. 
+Skipping "testdata/InvalidResourcesAreSkipped/resources/d3.yaml": Input contains additional files from supported file extensions (json/yaml) that do not contain a valid resource, error: 'Kind' is missing.
+ In case this file is expected to be a valid resource modify it accordingly. 
+Skipping testdata/InvalidResourcesAreSkipped/resources/d4.yaml: Input contains additional files from supported file extensions (json/yaml) that do not contain a valid resource, error: : mapping values are not allowed in this context.
+ In case this file is expected to be a valid resource modify it accordingly. 
+**********************************
+
+Cluster CR: apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
+Reference File: deploymentMetrics.yaml
+Diff Output: diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_dashboard-metrics-scraper TEMP/apps-v1_deployment_kubernetes-dashboard_dashboard-metrics-scraper
+--- TEMP/apps-v1_deployment_kubernetes-dashboard_dashboard-metrics-scraper	DATE
++++ TEMP/apps-v1_deployment_kubernetes-dashboard_dashboard-metrics-scraper	DATE
+@@ -10,7 +10,7 @@
+   revisionHistoryLimit: 10
+   selector:
+     matchLabels:
+-      k8s-app: dashboard-metrics-scraper
++      k8s-app: dashboard-metrics-scraper-diff
+   template:
+     metadata:
+       labels:
+
+**********************************
+
+Summary
+CRs with diffs: 1/1
+CRs in reference missing from the cluster: 1
+ExamplePart:
+  Dashboard:
+  - deploymentDashboard.yaml
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/InvalidResourcesAreSkipped/reference/deploymentDashboard.yaml
+++ b/pkg/compare/testdata/InvalidResourcesAreSkipped/reference/deploymentDashboard.yaml
@@ -1,0 +1,66 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        k8s-app: kubernetes-dashboard
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubernetes-dashboard
+          image: kubernetesui/dashboard:v2.7.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+          args:
+            - --auto-generate-certificates
+            - --namespace=kubernetes-dashboard
+            # Uncomment the following line to manually specify Kubernetes API server Host
+            # If not specified, Dashboard will attempt to auto discover the API server and connect
+            # to it. Uncomment only if the default does not work.
+            # - --apiserver-host=http://my-address:port
+          volumeMounts:
+            - name: kubernetes-dashboard-certs
+              mountPath: /certs
+              # Create on-disk volume to store exec logs
+            - mountPath: /tmp
+              name: tmp-volume
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /
+              port: 8443
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
+      volumes:
+        - name: kubernetes-dashboard-certs
+          secret:
+            secretName: kubernetes-dashboard-certs
+        - name: tmp-volume
+          emptyDir: { }
+      serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "kubernetes.io/os": linux
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule

--- a/pkg/compare/testdata/InvalidResourcesAreSkipped/reference/deploymentMetrics.yaml
+++ b/pkg/compare/testdata/InvalidResourcesAreSkipped/reference/deploymentMetrics.yaml
@@ -1,0 +1,19 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper
+  namespace: kubernetes-dashboard
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: dashboard-metrics-scraper
+  template:
+    metadata:
+      labels:
+        k8s-app: dashboard-metrics-scraper
+    spec:
+{{ if .spec.template.spec }}{{ .spec.template.spec | toYaml | indent 6 }}{{ end }}

--- a/pkg/compare/testdata/InvalidResourcesAreSkipped/reference/metadata.yaml
+++ b/pkg/compare/testdata/InvalidResourcesAreSkipped/reference/metadata.yaml
@@ -1,0 +1,8 @@
+Parts:
+  - name: ExamplePart
+    Components:
+      - name: Dashboard
+        type: Required
+        requiredTemplates:
+            - path: deploymentDashboard.yaml
+            - path: deploymentMetrics.yaml

--- a/pkg/compare/testdata/InvalidResourcesAreSkipped/resources/d1.json
+++ b/pkg/compare/testdata/InvalidResourcesAreSkipped/resources/d1.json
@@ -1,0 +1,5 @@
+{
+  "glossary": {
+    "title": "example glossary"
+      }
+}

--- a/pkg/compare/testdata/InvalidResourcesAreSkipped/resources/d2.yaml
+++ b/pkg/compare/testdata/InvalidResourcesAreSkipped/resources/d2.yaml
@@ -1,0 +1,52 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper
+  namespace: kubernetes-dashboard
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: dashboard-metrics-scraper-diff
+  template:
+    metadata:
+      labels:
+        k8s-app: dashboard-metrics-scraper
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: dashboard-metrics-scraper
+          image: kubernetesui/metrics-scraper:v1.0.8
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /
+              port: 8000
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-volume
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
+      serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "kubernetes.io/os": linux
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      volumes:
+        - name: tmp-volume
+          emptyDir: { }

--- a/pkg/compare/testdata/InvalidResourcesAreSkipped/resources/d3.yaml
+++ b/pkg/compare/testdata/InvalidResourcesAreSkipped/resources/d3.yaml
@@ -1,0 +1,14 @@
+# Resource With No Kind
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper
+  namespace: kubernetes-dashboard
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: dashboard-metrics-scraper-diff
+

--- a/pkg/compare/testdata/InvalidResourcesAreSkipped/resources/d4.yaml
+++ b/pkg/compare/testdata/InvalidResourcesAreSkipped/resources/d4.yaml
@@ -1,0 +1,13 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper
+  namespace: kubernetes-dashboard
+spec:
+  replicas: 1
+    revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+                k8s-app: dashboard-metrics-scraper-diff


### PR DESCRIPTION
previously, when using the command in local mode with recursive mode enabled, the command would attempt to parse additional JSON/YAML files as resources. If any files were invalid, an error was presented to the user, and the compare results for other valid resources were not returned.

With this update, the command will now issue a warning for invalid resources instead of stopping execution. It will skip these problematic files and proceed to present the compare results for the valid resources.