### PR TITLE
clarify the success messages during live mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ Dockerfile.cross
 
 # Release artifacts
 dist/*
+
+# build
+kubectl-cluster_compare

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -555,18 +555,18 @@ func newSummary(reference *Reference, c *MetricsCorelatorDecorator, numDiffCRs i
 func (s Summary) String() string {
 	t := `
 Summary
-CRs with diffs: {{ .NumDiffCRs }}
+Diff count: {{ .NumDiffCRs }}
 {{- if ne (len  .RequiredCRS) 0 }}
 CRs in reference missing from the cluster: {{.NumMissing}} 
 {{ toYaml .RequiredCRS}}
 {{- else}}
-No CRs are missing from the cluster
+Successfully found all required reference resources from the cluster
 {{- end }}
 {{- if ne (len  .UnmatchedCRS) 0 }}
 Cluster CRs unmatched to reference CRs: {{len  .UnmatchedCRS}}
 {{ toYaml .UnmatchedCRS}}
 {{- else}}
-No CRs are unmatched to reference CRs
+Successfully compared all reference resources
 {{- end }}
 `
 	var buf bytes.Buffer

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/liveout.golden
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/liveout.golden
@@ -86,6 +86,6 @@ Diff Output: None
 **********************************
 
 Summary
-CRs with diffs: 0
-No CRs are missing from the cluster
-No CRs are unmatched to reference CRs
+Diff count: 0
+Successfully found all required reference resources from the cluster
+Successfully compared all reference resources

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/localout.golden
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/localout.golden
@@ -164,6 +164,6 @@ Diff Output: None
 **********************************
 
 Summary
-CRs with diffs: 0
-No CRs are missing from the cluster
-No CRs are unmatched to reference CRs
+Diff count: 0
+Successfully found all required reference resources from the cluster
+Successfully compared all reference resources

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/liveout.golden
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/liveout.golden
@@ -20,6 +20,6 @@ Diff Output: None
 **********************************
 
 Summary
-CRs with diffs: 0
-No CRs are missing from the cluster
-No CRs are unmatched to reference CRs
+Diff count: 0
+Successfully found all required reference resources from the cluster
+Successfully compared all reference resources

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/localout.golden
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/localout.golden
@@ -20,6 +20,6 @@ Diff Output: None
 **********************************
 
 Summary
-CRs with diffs: 0
-No CRs are missing from the cluster
-No CRs are unmatched to reference CRs
+Diff count: 0
+Successfully found all required reference resources from the cluster
+Successfully compared all reference resources

--- a/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/liveout.golden
+++ b/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/liveout.golden
@@ -40,9 +40,9 @@ Diff Output: diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-
 **********************************
 
 Summary
-CRs with diffs: 1
+Diff count: 1
 CRs in reference missing from the cluster: 1 
 ExamplePart:
   Dashboard:
   - deploymentDashboard.yaml
-No CRs are unmatched to reference CRs
+Successfully compared all reference resources

--- a/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/localout.golden
+++ b/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/localout.golden
@@ -40,9 +40,9 @@ Diff Output: diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-
 **********************************
 
 Summary
-CRs with diffs: 1
+Diff count: 1
 CRs in reference missing from the cluster: 1 
 ExamplePart:
   Dashboard:
   - deploymentDashboard.yaml
-No CRs are unmatched to reference CRs
+Successfully compared all reference resources

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/liveout.golden
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/liveout.golden
@@ -9,7 +9,7 @@ Diff Output: None
 **********************************
 
 Summary
-CRs with diffs: 0
+Diff count: 0
 CRs in reference missing from the cluster: 5 
 ExamplePart1:
   Dashboard1:
@@ -22,4 +22,4 @@ ExamplePart2:
   - cr.yaml
   Dashboard2:
   - crb.yaml
-No CRs are unmatched to reference CRs
+Successfully compared all reference resources

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/localout.golden
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/localout.golden
@@ -8,7 +8,7 @@ Diff Output: None
 **********************************
 
 Summary
-CRs with diffs: 0
+Diff count: 0
 CRs in reference missing from the cluster: 5 
 ExamplePart1:
   Dashboard1:
@@ -21,4 +21,4 @@ ExamplePart2:
   - cr.yaml
   Dashboard2:
   - crb.yaml
-No CRs are unmatched to reference CRs
+Successfully compared all reference resources

--- a/pkg/compare/testdata/OnlyResourcesThatWereNotMatchedBecauseMultipleMatchesAppearInSummary/localout.golden
+++ b/pkg/compare/testdata/OnlyResourcesThatWereNotMatchedBecauseMultipleMatchesAppearInSummary/localout.golden
@@ -3,7 +3,7 @@ More then one template with same apiVersion, metadata_namespace, kind. These tem
 **********************************
 
 Summary
-CRs with diffs: 0
+Diff count: 0
 CRs in reference missing from the cluster: 1 
 ExamplePart:
   DemonSets:

--- a/pkg/compare/testdata/ReffTemplateInSubDirNotReportedMissing/liveout.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirNotReportedMissing/liveout.golden
@@ -18,6 +18,6 @@ Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashbo
 **********************************
 
 Summary
-CRs with diffs: 1
-No CRs are missing from the cluster
-No CRs are unmatched to reference CRs
+Diff count: 1
+Successfully found all required reference resources from the cluster
+Successfully compared all reference resources

--- a/pkg/compare/testdata/ReffTemplateInSubDirNotReportedMissing/localout.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirNotReportedMissing/localout.golden
@@ -18,6 +18,6 @@ Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashbo
 **********************************
 
 Summary
-CRs with diffs: 1
-No CRs are missing from the cluster
-No CRs are unmatched to reference CRs
+Diff count: 1
+Successfully found all required reference resources from the cluster
+Successfully compared all reference resources

--- a/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/liveout.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/liveout.golden
@@ -34,6 +34,6 @@ Diff Output: diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-
 **********************************
 
 Summary
-CRs with diffs: 1
-No CRs are missing from the cluster
-No CRs are unmatched to reference CRs
+Diff count: 1
+Successfully found all required reference resources from the cluster
+Successfully compared all reference resources

--- a/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/localout.golden
+++ b/pkg/compare/testdata/ReffTemplateInSubDirWorksWithManualCorrelation/localout.golden
@@ -34,6 +34,6 @@ Diff Output: diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-
 **********************************
 
 Summary
-CRs with diffs: 1
-No CRs are missing from the cluster
-No CRs are unmatched to reference CRs
+Diff count: 1
+Successfully found all required reference resources from the cluster
+Successfully compared all reference resources

--- a/pkg/compare/testdata/ReffWithTemplateFunctionsRendersAsExpected/liveout.golden
+++ b/pkg/compare/testdata/ReffWithTemplateFunctionsRendersAsExpected/liveout.golden
@@ -18,6 +18,6 @@ Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashbo
 **********************************
 
 Summary
-CRs with diffs: 1
-No CRs are missing from the cluster
-No CRs are unmatched to reference CRs
+Diff count: 1
+Successfully found all required reference resources from the cluster
+Successfully compared all reference resources

--- a/pkg/compare/testdata/ReffWithTemplateFunctionsRendersAsExpected/localout.golden
+++ b/pkg/compare/testdata/ReffWithTemplateFunctionsRendersAsExpected/localout.golden
@@ -18,6 +18,6 @@ Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashbo
 **********************************
 
 Summary
-CRs with diffs: 1
-No CRs are missing from the cluster
-No CRs are unmatched to reference CRs
+Diff count: 1
+Successfully found all required reference resources from the cluster
+Successfully compared all reference resources

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/liveout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/liveout.golden
@@ -9,6 +9,6 @@ Diff Output: None
 **********************************
 
 Summary
-CRs with diffs: 0
-No CRs are missing from the cluster
-No CRs are unmatched to reference CRs
+Diff count: 0
+Successfully found all required reference resources from the cluster
+Successfully compared all reference resources

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/localout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/localout.golden
@@ -8,6 +8,6 @@ Diff Output: None
 **********************************
 
 Summary
-CRs with diffs: 0
-No CRs are missing from the cluster
-No CRs are unmatched to reference CRs
+Diff count: 0
+Successfully found all required reference resources from the cluster
+Successfully compared all reference resources

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/liveout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/liveout.golden
@@ -9,9 +9,9 @@ Diff Output: None
 **********************************
 
 Summary
-CRs with diffs: 0
+Diff count: 0
 CRs in reference missing from the cluster: 1 
 ExamplePart1:
   Dashboard1:
   - cm.yaml
-No CRs are unmatched to reference CRs
+Successfully compared all reference resources

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/localout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/localout.golden
@@ -8,9 +8,9 @@ Diff Output: None
 **********************************
 
 Summary
-CRs with diffs: 0
+Diff count: 0
 CRs in reference missing from the cluster: 1 
 ExamplePart1:
   Dashboard1:
   - cm.yaml
-No CRs are unmatched to reference CRs
+Successfully compared all reference resources

--- a/pkg/compare/testdata/TemplatesContainKindThatIsNotRecognizableInLiveCluster/liveout.golden
+++ b/pkg/compare/testdata/TemplatesContainKindThatIsNotRecognizableInLiveCluster/liveout.golden
@@ -9,9 +9,9 @@ Diff Output: None
 **********************************
 
 Summary
-CRs with diffs: 0
+Diff count: 0
 CRs in reference missing from the cluster: 1 
 ExamplePart:
   DemonSets:
   - apps.v1.KindNotSupportedByCluster.kube-system.kindnet.yaml
-No CRs are unmatched to reference CRs
+Successfully compared all reference resources

--- a/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localout.golden
@@ -3,7 +3,7 @@ More then one template with same apiVersion, metadata_namespace, kind. These tem
 **********************************
 
 Summary
-CRs with diffs: 0
+Diff count: 0
 CRs in reference missing from the cluster: 1 
 ExamplePart:
   DemonSets:

--- a/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localout.golden
@@ -3,7 +3,7 @@ More then one template with same apiVersion, metadata_name, metadata_namespace, 
 **********************************
 
 Summary
-CRs with diffs: 0
+Diff count: 0
 CRs in reference missing from the cluster: 1 
 ExamplePart:
   DemonSets:

--- a/pkg/compare/testdata/WhenUsingDiffAllFlag-AllUnmatchedResourcesAppearInSummary/localout.golden
+++ b/pkg/compare/testdata/WhenUsingDiffAllFlag-AllUnmatchedResourcesAppearInSummary/localout.golden
@@ -3,7 +3,7 @@ More then one template with same apiVersion, metadata_namespace, kind. These tem
 **********************************
 
 Summary
-CRs with diffs: 0
+Diff count: 0
 CRs in reference missing from the cluster: 1 
 ExamplePart:
   DemonSets:


### PR DESCRIPTION
Success messages when running against live cluster should be clarified a bit more. 

Feel free to suggest any alt. Basically the goal is to be able to tell "All good" at a quick glance 

```
#prev

Summary
CRs with diffs: 1
No CRs are missing from the cluster
No CRs are unmatched to reference CRs
```

```
# cur 

Summary
Diff count: 1
Successfully found all required resources from the cluster
Successfully compared all reference resources
```

Additional update the gitignore to ignore local build

/cc @AlinaSecret  @nocturnalastro 
