### PR TITLE
Fix use of template functions declared in the same file

### DIFF
--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -404,6 +404,11 @@ error code:2`),
 			name:   "Invalid Resources Are Skipped",
 			checks: defaultChecks,
 		},
+		{
+			name:   "Ref Contains Templates With Function Templates In Same File",
+			mode:   []Mode{DefaultMode},
+			checks: defaultChecks,
+		},
 	}
 	tf := cmdtesting.NewTestFactory()
 	testFlags := flag.NewFlagSet("test", flag.ContinueOnError)

--- a/pkg/compare/parsing.go
+++ b/pkg/compare/parsing.go
@@ -154,7 +154,7 @@ func parseTemplates(templateReference []*ReferenceTemplate, functionTemplates []
 			continue
 		}
 		// recreate template with new name that includes path from reference root:
-		parsedTemp, _ = template.New(temp.Path).Funcs(FuncMap()).AddParseTree(temp.Path, parsedTemp.Tree)
+		parsedTemp, _ = parsedTemp.New(temp.Path).AddParseTree(temp.Path, parsedTemp.Lookup(path.Base(temp.Path)).Tree)
 		if len(functionTemplates) > 0 {
 			parsedTemp, err = parsedTemp.ParseFS(fsys, functionTemplates...)
 			if err != nil {

--- a/pkg/compare/testdata/RefContainsTemplatesWithFunctionTemplatesInSameFile/localerr.golden
+++ b/pkg/compare/testdata/RefContainsTemplatesWithFunctionTemplatesInSameFile/localerr.golden
@@ -1,0 +1,2 @@
+
+error code:1

--- a/pkg/compare/testdata/RefContainsTemplatesWithFunctionTemplatesInSameFile/localout.golden
+++ b/pkg/compare/testdata/RefContainsTemplatesWithFunctionTemplatesInSameFile/localout.golden
@@ -1,0 +1,22 @@
+**********************************
+
+Cluster CR: v1_ConfigMap_kubernetes-dashboard_kubernetes-dashboard-settings
+Reference File: cm.yaml
+Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings
+--- TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings	DATE
++++ TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings	DATE
+@@ -2,6 +2,6 @@
+ kind: ConfigMap
+ metadata:
+   labels:
+-    k8s-app: kubernetes-dashboardfunction was called successfully from same file
++    k8s-app: kubernetes-dashboard
+   name: kubernetes-dashboard-settings
+   namespace: kubernetes-dashboard
+
+**********************************
+
+Summary
+CRs with diffs: 1/1
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefContainsTemplatesWithFunctionTemplatesInSameFile/reference/cm.yaml
+++ b/pkg/compare/testdata/RefContainsTemplatesWithFunctionTemplatesInSameFile/reference/cm.yaml
@@ -1,0 +1,11 @@
+{{- define "addBlob" -}}
+  function was called successfully from same file
+  {{- end -}}
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard {{- template "addBlob" }}
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard

--- a/pkg/compare/testdata/RefContainsTemplatesWithFunctionTemplatesInSameFile/reference/metadata.yaml
+++ b/pkg/compare/testdata/RefContainsTemplatesWithFunctionTemplatesInSameFile/reference/metadata.yaml
@@ -1,0 +1,7 @@
+Parts:
+  - name: ExamplePart
+    Components:
+      - name: DemonSets
+        type: Required
+        requiredTemplates:
+          - path: cm.yaml

--- a/pkg/compare/testdata/RefContainsTemplatesWithFunctionTemplatesInSameFile/resources/cm.yaml
+++ b/pkg/compare/testdata/RefContainsTemplatesWithFunctionTemplatesInSameFile/resources/cm.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard


### PR DESCRIPTION
When using template functions that are declared in the same file as
 the templates, an error would be returned specifying that the function
 is not found. This commit fixes this behavior and also adds a test case 
that ensures that the bug has been fixed.