### PR TITLE
Move funcmap and add template functions docs

### DIFF
--- a/docs/templating-functions.md
+++ b/docs/templating-functions.md
@@ -1,0 +1,6 @@
+# Templating functions
+
+On top of golangs normal templating we provide some functions to make writitng references easier.
+The (sprig functions)[http://masterminds.github.io/sprig/] are included along with some other functions that can be found in the (subpackages pkg.go.dev page)[https://pkg.go.dev/github.com/openshift/kube-compare/pkg/funcmap#pkg-functions]
+
+If you want to custom functions you can define them as a templates and include them a paths under `templateFunctionFiles` at the root of your reference `metadata.yml`

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -17,6 +17,7 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/gosimple/slug"
+	"github.com/openshift/kube-compare/pkg/funcmap"
 	"github.com/openshift/kube-compare/pkg/groups"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
@@ -638,7 +639,7 @@ No CRs are unmatched to reference CRs
 {{- end }}
 `
 	var buf bytes.Buffer
-	tmpl, _ := template.New("Summary").Funcs(template.FuncMap{"toYaml": toYAML}).Parse(t)
+	tmpl, _ := template.New("Summary").Funcs(template.FuncMap{"toYaml": funcmap.ToYAML}).Parse(t)
 	_ = tmpl.Execute(&buf, s)
 	return strings.TrimSpace(buf.String())
 }

--- a/pkg/compare/parsing.go
+++ b/pkg/compare/parsing.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"text/template"
 
+	"github.com/openshift/kube-compare/pkg/funcmap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
 )
@@ -148,13 +149,14 @@ func parseYaml[T any](fsys fs.FS, filePath string, structType *T, fileNotFoundEr
 func parseTemplates(templateReference []*ReferenceTemplate, functionTemplates []string, fsys fs.FS) ([]*ReferenceTemplate, error) {
 	var errs []error
 	for _, temp := range templateReference {
-		parsedTemp, err := template.New(path.Base(temp.Path)).Funcs(FuncMap()).ParseFS(fsys, temp.Path)
+		parsedTemp, err := template.New(path.Base(temp.Path)).Funcs(funcmap.FuncMap()).ParseFS(fsys, temp.Path)
 		if err != nil {
 			errs = append(errs, fmt.Errorf(templatesCantBeParsed, temp.Path, err))
 			continue
 		}
 		// recreate template with new name that includes path from reference root:
-		parsedTemp, _ = template.New(temp.Path).Funcs(FuncMap()).AddParseTree(temp.Path, parsedTemp.Tree)
+		parsedTemp, _ = template.New(temp.Path).Funcs(funcmap.FuncMap()).AddParseTree(temp.Path, parsedTemp.Tree)
+
 		if len(functionTemplates) > 0 {
 			parsedTemp, err = parsedTemp.ParseFS(fsys, functionTemplates...)
 			if err != nil {

--- a/pkg/funcmap/funcmap.go
+++ b/pkg/funcmap/funcmap.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier:Apache-2.0
 
-package compare
+package funcmap
 
 import (
 	"bytes"
@@ -35,13 +35,13 @@ func FuncMap() template.FuncMap {
 
 	// Add some extra functionality
 	extra := template.FuncMap{
-		"toToml":        toTOML,
-		"toYaml":        toYAML,
-		"fromYaml":      fromYAML,
-		"fromYamlArray": fromYAMLArray,
-		"toJson":        toJSON,
-		"fromJson":      fromJSON,
-		"fromJsonArray": fromJSONArray,
+		"toToml":        ToTOML,
+		"toYaml":        ToYAML,
+		"fromYaml":      FromYAML,
+		"fromYamlArray": FromYAMLArray,
+		"toJson":        ToJSON,
+		"fromJson":      FromJSON,
+		"fromJsonArray": FromJSONArray,
 	}
 
 	for k, v := range extra {
@@ -51,11 +51,11 @@ func FuncMap() template.FuncMap {
 	return f
 }
 
-// toYAML takes an interface, marshals it to yaml, and returns a string. It will
+// ToYAML takes an interface, marshals it to yaml, and returns a string. It will
 // always return a string, even on marshal error (empty string).
 //
 // This is designed to be called from a template.
-func toYAML(v any) string {
+func ToYAML(v any) string {
 	data, err := yaml.Marshal(v)
 	if err != nil {
 		// Swallow errors inside of a template.
@@ -64,13 +64,13 @@ func toYAML(v any) string {
 	return strings.TrimSuffix(string(data), "\n")
 }
 
-// fromYAML converts a YAML document into a map[string]any.
+// FromYAML converts a YAML document into a map[string]any.
 //
 // This is not a general-purpose YAML parser, and will not parse all valid
 // YAML documents. Additionally, because its intended use is within templates
 // it tolerates errors. It will insert the returned error message string into
 // m["Error"] in the returned map.
-func fromYAML(str string) map[string]any {
+func FromYAML(str string) map[string]any {
 	m := map[string]any{}
 
 	if err := yaml.Unmarshal([]byte(str), &m); err != nil {
@@ -79,13 +79,13 @@ func fromYAML(str string) map[string]any {
 	return m
 }
 
-// fromYAMLArray converts a YAML array into a []any.
+// FromYAMLArray converts a YAML array into a []any.
 //
 // This is not a general-purpose YAML parser, and will not parse all valid
 // YAML documents. Additionally, because its intended use is within templates
 // it tolerates errors. It will insert the returned error message string as
 // the first and only item in the returned array.
-func fromYAMLArray(str string) []any {
+func FromYAMLArray(str string) []any {
 	a := []any{}
 
 	if err := yaml.Unmarshal([]byte(str), &a); err != nil {
@@ -94,11 +94,11 @@ func fromYAMLArray(str string) []any {
 	return a
 }
 
-// toTOML takes an interface, marshals it to toml, and returns a string. It will
+// ToTOML takes an interface, marshals it to toml, and returns a string. It will
 // always return a string, even on marshal error (empty string).
 //
 // This is designed to be called from a template.
-func toTOML(v any) string {
+func ToTOML(v any) string {
 	b := bytes.NewBuffer(nil)
 	e := toml.NewEncoder(b)
 	err := e.Encode(v)
@@ -108,11 +108,11 @@ func toTOML(v any) string {
 	return b.String()
 }
 
-// toJSON takes an interface, marshals it to json, and returns a string. It will
+// ToJSON takes an interface, marshals it to json, and returns a string. It will
 // always return a string, even on marshal error (empty string).
 //
 // This is designed to be called from a template.
-func toJSON(v any) string {
+func ToJSON(v any) string {
 	data, err := json.Marshal(v)
 	if err != nil {
 		// Swallow errors inside of a template.
@@ -121,13 +121,13 @@ func toJSON(v any) string {
 	return string(data)
 }
 
-// fromJSON converts a JSON document into a map[string]any.
+// FromJSON converts a JSON document into a map[string]any.
 //
 // This is not a general-purpose JSON parser, and will not parse all valid
 // JSON documents. Additionally, because its intended use is within templates
 // it tolerates errors. It will insert the returned error message string into
 // m["Error"] in the returned map.
-func fromJSON(str string) map[string]any {
+func FromJSON(str string) map[string]any {
 	m := make(map[string]any)
 
 	if err := json.Unmarshal([]byte(str), &m); err != nil {
@@ -136,13 +136,13 @@ func fromJSON(str string) map[string]any {
 	return m
 }
 
-// fromJSONArray converts a JSON array into a []any.
+// FromJSONArray converts a JSON array into a []any.
 //
 // This is not a general-purpose JSON parser, and will not parse all valid
 // JSON documents. Additionally, because its intended use is within templates
 // it tolerates errors. It will insert the returned error message string as
 // the first and only item in the returned array.
-func fromJSONArray(str string) []any {
+func FromJSONArray(str string) []any {
 	a := []any{}
 
 	if err := json.Unmarshal([]byte(str), &a); err != nil {


### PR DESCRIPTION
#20 

Note the url https://pkg.go.dev/github.com/openshift/kube-compare/pkg/funcmap#pkg-functions wont be live until we merge it but https://pkg.go.dev/github.com/openshift/kube-compare/pkg/compare#pkg-functions to see how it would look - although currently the to/from helper functions are not visible as they are currently private