### PR TITLE
CNF-13524: Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN go work vendor
 RUN make cross-build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-builder-multi-openshift-4.17 AS builder-rhel-9
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-builder-multi-openshift-4.17 AS builder-rhel-9
 WORKDIR /go/src/github.com/openshift/kube-compare
 COPY . .
 RUN go work vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# This Dockerfile builds an image containing the Mac and Windows version of kube-compare
+# layered on top of the Linux cli image.
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-builder-multi-openshift-4.17 AS builder-rhel-8
+WORKDIR /go/src/github.com/openshift/kube-compare
+COPY . .
+RUN go work vendor
+RUN make cross-build --warn-undefined-variables
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-builder-multi-openshift-4.17 AS builder-rhel-9
+WORKDIR /go/src/github.com/openshift/kube-compare
+COPY . .
+RUN go work vendor
+RUN make cross-build --warn-undefined-variables
+
+FROM --platform=linux/amd64 registry.ci.openshift.org/ocp/4.17:cli
+
+COPY --from=builder-rhel-9 /go/src/github.com/openshift/kube-compare/_output/bin/ /usr/share/openshift/
+
+RUN cd /usr/share/openshift && \
+    ln -sf /usr/share/openshift/linux_amd64/kube-compare /usr/bin/kube-compare && \
+    mv windows_amd64 windows && \
+    mv darwin_amd64 mac && \
+    mv darwin_arm64 mac_arm64
+
+COPY --from=builder-rhel-8 /go/src/github.com/openshift/kube-compare/_output/bin/linux_amd64/kubectl-cluster_compare /usr/share/openshift/linux_amd64/kube-compare.rhel8
+COPY --from=builder-rhel-8 /go/src/github.com/openshift/kube-compare/_output/bin/linux_arm64/kubectl-cluster_compare /usr/share/openshift/linux_arm64/kube-compare.rhel8
+COPY --from=builder-rhel-8 /go/src/github.com/openshift/kube-compare/_output/bin/linux_ppc64le/kubectl-cluster_compare /usr/share/openshift/linux_ppc64le/kube-compare.rhel8
+COPY --from=builder-rhel-8 /go/src/github.com/openshift/kube-compare/_output/bin/linux_s390x/kubectl-cluster_compare /usr/share/openshift/linux_s390x/kube-compare.rhel8
+
+COPY --from=builder-rhel-9 /go/src/github.com/openshift/kube-compare/_output/bin/linux_amd64/kubectl-cluster_compare /usr/share/openshift/linux_amd64/kube-compare.rhel9
+COPY --from=builder-rhel-9 /go/src/github.com/openshift/kube-compare/_output/bin/linux_arm64/kubectl-cluster_compare /usr/share/openshift/linux_arm64/kube-compare.rhel9
+COPY --from=builder-rhel-9 /go/src/github.com/openshift/kube-compare/_output/bin/linux_ppc64le/kubectl-cluster_compare /usr/share/openshift/linux_ppc64le/kube-compare.rhel9
+COPY --from=builder-rhel-9 /go/src/github.com/openshift/kube-compare/_output/bin/linux_s390x/kubectl-cluster_compare /usr/share/openshift/linux_s390x/kube-compare.rhel9
+
+COPY --from=builder-rhel-8 /go/src/github.com/openshift/kube-compare/LICENSE /usr/share/openshift/LICENSE

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ OUTPUT_DIR :=_output
 GO_BUILD_BINDIR ?=$(OUTPUT_DIR)/bin
 CROSS_BUILD_BINDIR ?=$(OUTPUT_DIR)/bin
 
+# Build based on OS and Arch. Full list available in https://pkg.go.dev/internal/platform#pkg-variables
 .PHONY: build
 build:
 	mkdir -p $(GO_BUILD_BINDIR)
@@ -59,6 +60,10 @@ markdownlint: markdownlint-image  ## run the markdown linter
 		--env PULL_BASE_SHA=$(PULL_BASE_SHA) \
 		-v $$(pwd):/workdir:Z \
 		$(IMAGE_NAME)-markdownlint:latest
+
+.PHONY: image-build
+image-build:
+	$(ENGINE) build . -t $(IMAGE_NAME):latest
 
 .PHONY: release-dry-run
 release-dry-run:

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,24 @@ IMAGE_NAME=kube-compare
 PACKAGE_NAME          := github.com/openshift/kube-compare
 GOLANG_CROSS_VERSION  ?= v1.22.3
 
+# Default values for GOOS and GOARCH
+GOOS ?= linux
+GOARCH ?= amd64
+
+# These tags make sure we can statically link and avoid shared dependencies
+GO_BUILD_FLAGS :=-tags 'include_gcs include_oss containers_image_openpgp gssapi'
+GO_BUILD_FLAGS_DARWIN :=-tags 'include_gcs include_oss containers_image_openpgp'
+GO_BUILD_FLAGS_WINDOWS :=-tags 'include_gcs include_oss containers_image_openpgp'
+GO_BUILD_FLAGS_LINUX_CROSS :=-tags 'include_gcs include_oss containers_image_openpgp'
+
+OUTPUT_DIR :=_output
+GO_BUILD_BINDIR ?=$(OUTPUT_DIR)/bin
+CROSS_BUILD_BINDIR ?=$(OUTPUT_DIR)/bin
 
 .PHONY: build
 build:
-	go build ./cmd/kubectl-cluster_compare.go
+	mkdir -p $(GO_BUILD_BINDIR)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GO_BUILD_FLAGS) -o $(GO_BUILD_BINDIR)/kubectl-cluster_compare ./cmd/kubectl-cluster_compare.go
 
 .PHONY: test
 test:
@@ -46,7 +60,6 @@ markdownlint: markdownlint-image  ## run the markdown linter
 		-v $$(pwd):/workdir:Z \
 		$(IMAGE_NAME)-markdownlint:latest
 
-
 .PHONY: release-dry-run
 release-dry-run:
 	@$(ENGINE) run \
@@ -69,3 +82,41 @@ release:
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
 		release --clean
+
+.PHONY: cross-build-darwin-amd64
+cross-build-darwin-amd64:
+	+@GOOS=darwin GOARCH=amd64 GO_BUILD_FLAGS="$(GO_BUILD_FLAGS_DARWIN)" GO_BUILD_BINDIR=$(CROSS_BUILD_BINDIR)/darwin_amd64 $(MAKE) --no-print-directory build
+
+.PHONY: cross-build-darwin-arm64
+cross-build-darwin-arm64:
+	+@GOOS=darwin GOARCH=arm64 GO_BUILD_FLAGS="$(GO_BUILD_FLAGS_DARWIN)" GO_BUILD_BINDIR=$(CROSS_BUILD_BINDIR)/darwin_arm64 $(MAKE) --no-print-directory build
+
+.PHONY: cross-build-windows-amd64
+cross-build-windows-amd64:
+	+@GOOS=windows GOARCH=amd64 GO_BUILD_FLAGS="$(GO_BUILD_FLAGS_WINDOWS)" GO_BUILD_BINDIR=$(CROSS_BUILD_BINDIR)/windows_amd64 $(MAKE) --no-print-directory build
+
+.PHONY: cross-build-linux-amd64
+cross-build-linux-amd64:
+	+@GOOS=linux GOARCH=amd64 GO_BUILD_FLAGS="$(GO_BUILD_FLAGS_LINUX_CROSS)" GO_BUILD_BINDIR=$(CROSS_BUILD_BINDIR)/linux_amd64 $(MAKE) --no-print-directory build
+
+.PHONY: cross-build-linux-arm64
+cross-build-linux-arm64:
+	+@GOOS=linux GOARCH=arm64 GO_BUILD_FLAGS="$(GO_BUILD_FLAGS_LINUX_CROSS)" GO_BUILD_BINDIR=$(CROSS_BUILD_BINDIR)/linux_arm64 $(MAKE) --no-print-directory build
+
+.PHONY: cross-build-linux-ppc64le
+cross-build-linux-ppc64le:
+	+@GOOS=linux GOARCH=ppc64le GO_BUILD_FLAGS="$(GO_BUILD_FLAGS_LINUX_CROSS)" GO_BUILD_BINDIR=$(CROSS_BUILD_BINDIR)/linux_ppc64le $(MAKE) --no-print-directory build
+
+.PHONY: cross-build-linux-s390x
+cross-build-linux-s390x:
+	+@GOOS=linux GOARCH=s390x GO_BUILD_FLAGS="$(GO_BUILD_FLAGS_LINUX_CROSS)" GO_BUILD_BINDIR=$(CROSS_BUILD_BINDIR)/linux_s390x $(MAKE) --no-print-directory build
+
+.PHONY: cross-build
+cross-build: cross-build-darwin-amd64 cross-build-darwin-arm64 cross-build-windows-amd64 cross-build-linux-amd64 cross-build-linux-arm64 cross-build-linux-ppc64le cross-build-linux-s390x
+
+.PHONY: clean-cross-build
+clean-cross-build:
+	$(RM) -r '$(GO_BUILD_BINDIR)'
+	if [ -d '$(OUTPUT_DIR)' ]; then \
+		$(RM) -r '$(OUTPUT_DIR)'; \
+	fi

--- a/README.md
+++ b/README.md
@@ -111,3 +111,5 @@ See the included [test cases](pkg/compare/testdata/) for more examples of refere
 [Building a Reference Config](docs/reference-config-guide.md)
 
 [Developer Intro](docs/dev.md)
+
+[Build Image](docs/image-build.md)

--- a/docs/image-build.md
+++ b/docs/image-build.md
@@ -1,0 +1,24 @@
+
+# Kube-compare image build
+
+## Build container
+
+```bash
+make image-build
+```
+
+## Copy binary locally
+
+- One option it to build the binary locally
+
+```bash
+make cross-build
+```
+
+- Another option is to extract the binary from the container
+
+```bash
+docker create --name kube-compare kube-compare:latest
+docker cp kube-compare:/usr/share/openshift/linux_amd64/kube-compare.rhel9 ./kube-compare.rhel9
+docker rm -f kube-compare
+```


### PR DESCRIPTION
- Add Dockerfile
- Modify makefile to support cross-platform build

Building the image
```bash
make image-build 
```

Getting the binaries
```bash
➜ podman run --platform linux/amd64 -it --entrypoint /bin/bash kube-compare
[root@f1b611b07d36 /]# ls
afs  bin  boot	dev  etc  home	lib  lib64  lost+found	media  mnt  opt  proc  root  run  sbin	srv  sys  tmp  usr  var
[root@f1b611b07d36 /]# ls /usr/share/openshift
LICENSE  linux_amd64  linux_arm64  linux_ppc64le  linux_s390x  mac  mac_arm64  windows
```

Based on [oc cli-artifacts](https://github.com/openshift/oc/blob/master/images/cli-artifacts/Dockerfile.rhel) image