### PR TITLE
use scratch as final base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 RUN go work vendor
 RUN make cross-build --warn-undefined-variables
 
-FROM --platform=linux/amd64 registry.ci.openshift.org/ocp/4.17:cli
+FROM --platform=linux/amd64 registry.ci.openshift.org/ocp/4.17:cli as final-builder
 
 COPY --from=builder-rhel-9 /go/src/github.com/openshift/kube-compare/_output/bin/ /usr/share/openshift/
 
@@ -33,3 +33,7 @@ COPY --from=builder-rhel-9 /go/src/github.com/openshift/kube-compare/_output/bin
 COPY --from=builder-rhel-9 /go/src/github.com/openshift/kube-compare/_output/bin/linux_s390x/kubectl-cluster_compare /usr/share/openshift/linux_s390x/kube-compare.rhel9
 
 COPY --from=builder-rhel-8 /go/src/github.com/openshift/kube-compare/LICENSE /usr/share/openshift/LICENSE
+
+FROM scratch
+WORKDIR /usr/share/openshift/
+COPY --from=final-builder /usr/share/openshift/ /usr/share/openshift/

--- a/docs/image-build.md
+++ b/docs/image-build.md
@@ -21,4 +21,9 @@ make cross-build
 docker create --name kube-compare kube-compare:latest
 docker cp kube-compare:/usr/share/openshift/linux_amd64/kube-compare.rhel9 ./kube-compare.rhel9
 docker rm -f kube-compare
+
+# run 
+export PATH=$PWD:$PATH
+mv kube-compare.rhel9 kubectl-cluster_compare
+oc cluster-compare -h
 ```


### PR DESCRIPTION
Using scratch as base image to effectively remove any security concerns and use the container as simple storage for all the binaries 

https://hub.docker.com/_/scratch/ 

tested with `quay.io/npathan/dev:kc-8-2`

/cc @natifridman 
/cc @nocturnalastro 