### PR TITLE
Move metadata to ReferenceTemplate and do some cleanup

### DIFF
--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -336,9 +336,12 @@ func (o *Options) setupCorrelators() error {
 // types supported by the live cluster in order to not raise errors by the visitor. In a case the reference includes types that
 // are not supported by the user a warning will be created.
 func (o *Options) setLiveSearchTypes(f kcmdutil.Factory) error {
-	requestedTypes, err := groups.Divide(o.templates, func(element *unstructured.Unstructured) ([]int, error) {
-		return []int{0}, nil
-	}, extractMetadata, createGroupHashFunc([][]string{{"kind"}}))
+	requestedTypes, err := groups.Divide(
+		o.templates,
+		func(element *unstructured.Unstructured) ([]int, error) { return []int{0}, nil },
+		func(t *ReferenceTemplate) (*unstructured.Unstructured, error) { return t.metadata, nil },
+		createGroupHashFunc([][]string{{"kind"}}),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to group templates: %w", err)
 	}

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -508,11 +508,12 @@ func getCommand(t *testing.T, test *Test, modeIndex int, tf *cmdtesting.TestFact
 }
 
 func setClient(t *testing.T, resources []*unstructured.Unstructured, tf *cmdtesting.TestFactory) {
-	resourcesByType, _ := groups.Divide(resources, func(element *unstructured.Unstructured) ([]int, error) {
-		return []int{0}, nil
-	}, func(e *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-		return e, nil
-	}, createGroupHashFunc([][]string{{"kind"}}))
+	resourcesByType, _ := groups.Divide(
+		resources,
+		func(element *unstructured.Unstructured) ([]int, error) { return []int{0}, nil },
+		func(e *unstructured.Unstructured) (*unstructured.Unstructured, error) { return e, nil },
+		createGroupHashFunc([][]string{{"kind"}}),
+	)
 	resourcesByKind := lo.MapKeys(resourcesByType[0], func(value []*unstructured.Unstructured, key string) string {
 		// Converted to URL Path Format:
 		return fmt.Sprintf("/%ss", strings.ToLower(key))

--- a/pkg/compare/correlator.go
+++ b/pkg/compare/correlator.go
@@ -134,7 +134,12 @@ func NewGroupCorrelator(fieldGroups [][][]string, templates []*ReferenceTemplate
 		functionGroups = append(functionGroups, createGroupHashFunc(group))
 	}
 	core := GroupCorrelator{fieldGroups: fieldGroups, GroupFunctions: functionGroups}
-	mappings, err := groups.Divide(templates, core.getGroupsFunction(), extractMetadata, functionGroups...)
+	mappings, err := groups.Divide(
+		templates,
+		core.getGroupsFunction(),
+		func(t *ReferenceTemplate) (*unstructured.Unstructured, error) { return t.metadata, nil },
+		functionGroups...,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to group templates: %w", err)
 	}

--- a/pkg/compare/testdata/TemplateIsntYAMLAfterExecutionWithEmptyMap/localerr.golden
+++ b/pkg/compare/testdata/TemplateIsntYAMLAfterExecutionWithEmptyMap/localerr.golden
@@ -1,2 +1,2 @@
-error: failed to group templates: failed to constuct template: template: apps.v1.DaemonSet.kube-system.kindnet.yaml:5:61: executing "apps.v1.DaemonSet.kube-system.kindnet.yaml" at <len .spec.annotations>: error calling len: reflect: call of reflect.Value.Type on zero Value
+error: failed to constuct template: template: apps.v1.DaemonSet.kube-system.kindnet.yaml:5:61: executing "apps.v1.DaemonSet.kube-system.kindnet.yaml" at <len .spec.annotations>: error calling len: reflect: call of reflect.Value.Type on zero Value
 error code:2


### PR DESCRIPTION
Remove extractMetadata, moving metadata into the ReferenceTemplate. 

This allows moves errors that may occur with extracting the metadata
earlier in the process.
Also move error wrap into the stored error message string to simplify
generation of the error. 