### PR TITLE
Fix bug overwrite when using prefix paths

### DIFF
--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -566,7 +566,7 @@ func findFieldPaths(object map[string]any, fields []*ManifestPath) [][]string {
 			if mapping, ok := val.(map[string]any); ok {
 				for key := range mapping {
 					if strings.HasPrefix(key, prefix) {
-						newPath := start
+						newPath := append([]string{}, start...)
 						newPath = append(newPath, key)
 						result = append(result, newPath)
 					}

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShownPrefix/resources/d3.yaml
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShownPrefix/resources/d3.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
+        olm.operatorgroup.uid/6a093c10-3154-4e38-8ae0-71197c10a259: ""
     spec:
       securityContext:
         seccompProfile:


### PR DESCRIPTION
Was accidently reusing the path parts when creating a new path entry This meant that prefixed paths would work the first time but would fail on any attempts after that.