### PR TITLE
CNF-13744: Point reference flag to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,25 +20,25 @@ A reference configuration is required in order to run. A reference configuration
 Compare a known valid reference configuration with a live cluster:
 
 ```bash
-kubectl cluster-compare -r ./reference
+kubectl cluster-compare -r ./reference/metadata.yaml
 ```
   
 Compare a known valid reference configuration with a local set of CRs:
 
 ```bash
-kubectl cluster-compare -r ./reference -f ./crsdir -R
+kubectl cluster-compare -r ./reference/metadata.yaml -f ./crsdir -R
 ```
   
 Compare a known valid reference configuration with a live cluster and with a user config:
 
 ```bash
-kubectl cluster-compare -r ./reference -c ./user_config
+kubectl cluster-compare -r ./reference/metadata.yaml -c ./user_config
 ```
   
 Run a known valid reference configuration with an `oc must-gather` output:
 
 ```bash
-kubectl cluster-compare -r ./reference -f "must-gather*/*/cluster-scoped-resources","must-gather*/*/namespaces" -R
+kubectl cluster-compare -r ./reference/metadata.yaml -f "must-gather*/*/cluster-scoped-resources","must-gather*/*/namespaces" -R
 ```
 
 Run `kubectl cluster-compare --help` for a more extensive usage description.

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -35,6 +35,8 @@ import (
 var update = flag.Bool("update", false, "update .golden files")
 
 const TestRefDirName = "reference"
+const TestRefConfigFileName = "metadata.yaml"
+const TestRefConfigFile = TestRefDirName + "/" + TestRefConfigFileName
 
 var TestDirs = "testdata"
 
@@ -268,13 +270,7 @@ func TestCompareRun(t *testing.T) {
 	tests := []Test{
 		defaultTest("No Input").
 			skipReferenceFlag(),
-		defaultTest("Reference Directory Doesnt Exist"),
-		defaultTest("Reference Config File Doesnt Exist").
-			withChecks(Checks{Out: defaultCheckOut,
-				Err: matchErrorRegexCheck(
-					`Reference config file not found. error: open .*metadata.yaml: no such file or directory`,
-				),
-			}),
+		defaultTest("Reference Config File Doesnt Exist"),
 		defaultTest("Reference Config File Isnt Valid YAML"),
 		defaultTest("Reference Contains Templates That Dont Exist"),
 		defaultTest("Reference Contains Templates That Dont Parse"),
@@ -434,14 +430,14 @@ func getCommand(t *testing.T, test *Test, modeIndex int, tf *cmdtesting.TestFact
 			_, err = fmt.Fprint(w, string(body))
 			require.NoError(t, err)
 		}))
-		require.NoError(t, cmd.Flags().Set("reference", svr.URL))
+		require.NoError(t, cmd.Flags().Set("reference", svr.URL+"/"+TestRefConfigFileName))
 		t.Cleanup(func() {
 			svr.Close()
 		})
 
 	case LocalRef:
 		if !test.leaveTemplateDirEmpty {
-			require.NoError(t, cmd.Flags().Set("reference", path.Join(test.getTestDir(), TestRefDirName)))
+			require.NoError(t, cmd.Flags().Set("reference", path.Join(test.getTestDir(), TestRefConfigFile)))
 		}
 	}
 	return cmd

--- a/pkg/compare/parsing.go
+++ b/pkg/compare/parsing.go
@@ -229,9 +229,9 @@ const (
 	templatesFunctionsCantBeParsed = "an error occurred while parsing the template function files specified in the config. error: %w"
 )
 
-func getReference(fsys fs.FS) (Reference, error) {
+func getReference(fsys fs.FS, referenceFileName string) (Reference, error) {
 	result := Reference{}
-	err := parseYaml(fsys, ReferenceFileName, &result, refConfNotExistsError, refConfigNotInFormat)
+	err := parseYaml(fsys, referenceFileName, &result, refConfNotExistsError, refConfigNotInFormat)
 	if err != nil {
 		return result, err
 	}

--- a/pkg/compare/testdata/NoDiffs/localerr.golden
+++ b/pkg/compare/testdata/NoDiffs/localerr.golden
@@ -1,2 +1,0 @@
-
-error code:1

--- a/pkg/compare/testdata/NoInput/localerr.golden
+++ b/pkg/compare/testdata/NoInput/localerr.golden
@@ -1,3 +1,3 @@
-error: "Reference directory is required"
+error: "Reference config file is required"
 See 'compare -h' for help and examples
 error code:2

--- a/pkg/compare/testdata/ReferenceConfigFileDoesntExist/localerr.golden
+++ b/pkg/compare/testdata/ReferenceConfigFileDoesntExist/localerr.golden
@@ -1,2 +1,2 @@
-error: Reference config file not found. error: open ./testdata/ReferenceConfigFileDoesntExist/reference/metadata.yaml: no such file or directory 
+error: "Reference config file doesn't exist"
 error code:2

--- a/pkg/compare/testdata/ReferenceDirectoryDoesntExist/localerr.golden
+++ b/pkg/compare/testdata/ReferenceDirectoryDoesntExist/localerr.golden
@@ -1,2 +1,0 @@
-error: "Reference directory doesn't exist"
-error code:2

--- a/pkg/compare/testdata/YAMLOutput/localout.golden
+++ b/pkg/compare/testdata/YAMLOutput/localout.golden
@@ -3,9 +3,9 @@ Diffs:
   CorrelatedTemplate: deploymentDashboard.yaml
   DiffOutput: "diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard
     TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard\n---
-    TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard\tDATE\n+++ TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard\tDATE\n@@ -14,7 +14,7 @@\n   template:\n     metadata:\n       labels:\n-
-    \       k8s-app: kubernetes-dashboard\n+        k8s-app: kubernetes-dashboard-diff\n
-    \    spec:\n       containers:\n       - args:\n"
+    TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard\tDATE\n+++ TEMP/apps-v1_deployment_kubernetes-dashboard_kubernetes-dashboard\tDATE\n@@ -14,7 +14,7 @@\n   template:\n     metadata:\n       labels:\n-        k8s-app:
+    kubernetes-dashboard\n+        k8s-app: kubernetes-dashboard-diff\n     spec:\n
+    \      containers:\n       - args:\n"
 Summary:
   NumDiffCRs: 1
   NumMissing: 1


### PR DESCRIPTION
Point to config file instead of a directory

Before:
```
kubectl cluster-compare -r ./reference
```

After:
```
kubectl cluster-compare -r ./reference/metadata.yaml
```