### PR TITLE
Onboarding new component to OCP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,11 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-builder-multi-openshift-4.17 AS builder-rhel-8
 WORKDIR /go/src/github.com/openshift/kube-compare
 COPY . .
-RUN go work vendor
 RUN make cross-build --warn-undefined-variables
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-builder-multi-openshift-4.17 AS builder-rhel-9
 WORKDIR /go/src/github.com/openshift/kube-compare
 COPY . .
-RUN go work vendor
 RUN make cross-build --warn-undefined-variables
 
 FROM --platform=linux/amd64 registry.ci.openshift.org/ocp/4.17:cli as final-builder
@@ -34,6 +32,4 @@ COPY --from=builder-rhel-9 /go/src/github.com/openshift/kube-compare/_output/bin
 
 COPY --from=builder-rhel-8 /go/src/github.com/openshift/kube-compare/LICENSE /usr/share/openshift/LICENSE
 
-FROM scratch
 WORKDIR /usr/share/openshift/
-COPY --from=final-builder /usr/share/openshift/ /usr/share/openshift/

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 .PHONY: build
 build:
 	mkdir -p $(GO_BUILD_BINDIR)
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GO_BUILD_FLAGS) -o $(GO_BUILD_BINDIR)/kubectl-cluster_compare ./cmd/kubectl-cluster_compare.go
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -mod=vendor $(GO_BUILD_FLAGS) -o $(GO_BUILD_BINDIR)/kubectl-cluster_compare ./cmd/kubectl-cluster_compare.go
 
 # Install the plugin and completion script in /usr/local/bin
 .PHONY: install


### PR DESCRIPTION
Ref ticket: https://issues.redhat.com/browse/ART-10503

 - Use openshift-enterprise-cli as base
 - Remove `go work vendor` before build step
 - Ensure -mod=vendor when building