### PR TITLE
Add test permutations for optional/required components and optional/required templates

### DIFF
--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_optional_component_optionalTemplates_doesnt_existout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_optional_component_optionalTemplates_doesnt_existout.golden
@@ -1,0 +1,4 @@
+Summary
+CRs with diffs: 0/0
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_optional_component_optionalTemplates_existsout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_optional_component_optionalTemplates_existsout.golden
@@ -1,0 +1,4 @@
+Summary
+CRs with diffs: 0/1
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_optional_component_requiredTemplates_doesnt_existout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_optional_component_requiredTemplates_doesnt_existout.golden
@@ -1,0 +1,4 @@
+Summary
+CRs with diffs: 0/0
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_optional_component_requiredTemplates_existsout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_optional_component_requiredTemplates_existsout.golden
@@ -1,0 +1,4 @@
+Summary
+CRs with diffs: 0/1
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_required_component_optionalTemplates_doesnt_existout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_required_component_optionalTemplates_doesnt_existout.golden
@@ -1,0 +1,4 @@
+Summary
+CRs with diffs: 0/0
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_required_component_optionalTemplates_existsout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_required_component_optionalTemplates_existsout.golden
@@ -1,0 +1,4 @@
+Summary
+CRs with diffs: 0/1
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_required_component_requiredTemplates_doesnt_existerr.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_required_component_requiredTemplates_doesnt_existerr.golden
@@ -1,0 +1,2 @@
+
+error code:1

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_required_component_requiredTemplates_doesnt_existout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_required_component_requiredTemplates_doesnt_existout.golden
@@ -1,0 +1,7 @@
+Summary
+CRs with diffs: 0/0
+CRs in reference missing from the cluster: 1
+ExamplePart:
+  DemonSets:
+  - daemon_set_doesnt_exist.yaml
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_required_component_requiredTemplates_existsout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with1template_required_component_requiredTemplates_existsout.golden
@@ -1,0 +1,4 @@
+Summary
+CRs with diffs: 0/1
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_optional_component_optionalTemplates_1exists_1doesnt_existout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_optional_component_optionalTemplates_1exists_1doesnt_existout.golden
@@ -1,0 +1,4 @@
+Summary
+CRs with diffs: 0/1
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_optional_component_requiredTemplates_1exists_1doesnt_existerr.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_optional_component_requiredTemplates_1exists_1doesnt_existerr.golden
@@ -1,0 +1,2 @@
+
+error code:1

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_optional_component_requiredTemplates_1exists_1doesnt_existout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_optional_component_requiredTemplates_1exists_1doesnt_existout.golden
@@ -1,0 +1,7 @@
+Summary
+CRs with diffs: 0/1
+CRs in reference missing from the cluster: 1
+ExamplePart:
+  DemonSets:
+  - daemon_set_doesnt_exist.yaml
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_optional_component_requiredTemplates_both_dont_existout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_optional_component_requiredTemplates_both_dont_existout.golden
@@ -1,0 +1,4 @@
+Summary
+CRs with diffs: 0/0
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_optional_component_requiredTemplates_both_existout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_optional_component_requiredTemplates_both_existout.golden
@@ -1,0 +1,4 @@
+Summary
+CRs with diffs: 0/2
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_required_component_optionalTemplates_1exists_1doesnt_existout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_required_component_optionalTemplates_1exists_1doesnt_existout.golden
@@ -1,0 +1,4 @@
+Summary
+CRs with diffs: 0/1
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_required_component_requiredTemplates_1exists_1doesnt_existerr.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_required_component_requiredTemplates_1exists_1doesnt_existerr.golden
@@ -1,0 +1,2 @@
+
+error code:1

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_required_component_requiredTemplates_1exists_1doesnt_existout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_required_component_requiredTemplates_1exists_1doesnt_existout.golden
@@ -1,0 +1,7 @@
+Summary
+CRs with diffs: 0/1
+CRs in reference missing from the cluster: 1
+ExamplePart:
+  DemonSets:
+  - daemon_set_doesnt_exist.yaml
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_required_component_requiredTemplates_both_dont_existerr.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_required_component_requiredTemplates_both_dont_existerr.golden
@@ -1,0 +1,2 @@
+
+error code:1

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_required_component_requiredTemplates_both_dont_existout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_required_component_requiredTemplates_both_dont_existout.golden
@@ -1,0 +1,8 @@
+Summary
+CRs with diffs: 0/0
+CRs in reference missing from the cluster: 2
+ExamplePart:
+  DemonSets:
+  - daemon_set_doesnt_exist.yaml
+  - cm_doesnt_exist.yaml
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_required_component_requiredTemplates_both_existout.golden
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_required_component_requiredTemplates_both_existout.golden
@@ -1,0 +1,4 @@
+Summary
+CRs with diffs: 0/2
+No CRs are missing from the cluster
+No CRs are unmatched to reference CRs

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/cm_doesnt_exist.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/cm_doesnt_exist.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings-that-dont-exists
+  namespace: kubernetes-dashboard

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/cm_exists.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/cm_exists.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/daemon_set_doesnt_exist.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/daemon_set_doesnt_exist.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: SomeNSThatDoesntExist
+  name: Test1
+  annotations:
+    deprecated.daemonset.template.generation: "1"
+  generation: 1
+  labels:
+    app: kindnet
+    k8s-app: kindnet
+    tier: node
+
+

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/daemon_set_exists.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/daemon_set_exists.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: SomeNS
+  name: Test1
+  annotations:
+    deprecated.daemonset.template.generation: "1"
+  generation: 1
+  labels:
+    app: kindnet
+    k8s-app: kindnet
+    tier: node
+
+

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_optional_component_optionalTemplate_doesnt_exist.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_optional_component_optionalTemplate_doesnt_exist.yaml
@@ -1,0 +1,7 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Optional
+        optionalTemplates:
+          - path: daemon_set_doesnt_exist.yaml

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_optional_component_optionalTemplate_exists.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_optional_component_optionalTemplate_exists.yaml
@@ -1,0 +1,7 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Optional
+        optionalTemplates:
+          - path: daemon_set_exists.yaml

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_optional_component_requiredTemplate_doesnt_exist.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_optional_component_requiredTemplate_doesnt_exist.yaml
@@ -1,0 +1,7 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Optional
+        requiredTemplates:
+          - path: daemon_set_doesnt_exist.yaml

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_optional_component_requiredTemplate_exists.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_optional_component_requiredTemplate_exists.yaml
@@ -1,0 +1,7 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Optional
+        requiredTemplates:
+          - path: daemon_set_exists.yaml

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_required_component_optionalTemplate_doesnt_exist.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_required_component_optionalTemplate_doesnt_exist.yaml
@@ -1,0 +1,7 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Required
+        optionalTemplates:
+          - path: daemon_set_doesnt_exist.yaml

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_required_component_optionalTemplate_exists.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_required_component_optionalTemplate_exists.yaml
@@ -1,0 +1,7 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Required
+        optionalTemplates:
+          - path: daemon_set_exists.yaml

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_required_component_requiredTemplate_doesnt_exist.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_required_component_requiredTemplate_doesnt_exist.yaml
@@ -1,0 +1,7 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Required
+        requiredTemplates:
+          - path: daemon_set_doesnt_exist.yaml

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_required_component_requiredTemplate_exists.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with1template_required_component_requiredTemplate_exists.yaml
@@ -1,0 +1,7 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Required
+        requiredTemplates:
+          - path: daemon_set_exists.yaml

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_optional_component_both_optionalTemplate_1exists_1doesnt_exist.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_optional_component_both_optionalTemplate_1exists_1doesnt_exist.yaml
@@ -1,0 +1,8 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Optional
+        optionalTemplates:
+          - path: daemon_set_exists.yaml
+          - path: daemon_set_doesnt_exist.yaml

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_optional_component_both_requiredTemplate_1exists_1doesnt_exist.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_optional_component_both_requiredTemplate_1exists_1doesnt_exist.yaml
@@ -1,0 +1,8 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Optional
+        requiredTemplates:
+          - path: daemon_set_exists.yaml
+          - path: daemon_set_doesnt_exist.yaml

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_optional_component_both_requiredTemplate_both_dont_exist.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_optional_component_both_requiredTemplate_both_dont_exist.yaml
@@ -1,0 +1,9 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Optional
+        requiredTemplates:
+          - path: daemon_set_doesnt_exist.yaml
+          - path: cm_doesnt_exist.yaml
+

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_optional_component_both_requiredTemplate_both_exist.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_optional_component_both_requiredTemplate_both_exist.yaml
@@ -1,0 +1,9 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Optional
+        requiredTemplates:
+          - path: daemon_set_exists.yaml
+          - path: cm_exists.yaml
+

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_required_component_both_optionalTemplate_1exists_1doesnt_exist.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_required_component_both_optionalTemplate_1exists_1doesnt_exist.yaml
@@ -1,0 +1,8 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Required
+        optionalTemplates:
+          - path: daemon_set_exists.yaml
+          - path: daemon_set_doesnt_exist.yaml

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_required_component_both_requiredTemplate_1exists_1doesnt_exist.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_required_component_both_requiredTemplate_1exists_1doesnt_exist.yaml
@@ -1,0 +1,8 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Required
+        requiredTemplates:
+          - path: daemon_set_exists.yaml
+          - path: daemon_set_doesnt_exist.yaml

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_required_component_both_requiredTemplate_both_dont_exist.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_required_component_both_requiredTemplate_both_dont_exist.yaml
@@ -1,0 +1,9 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Required
+        requiredTemplates:
+          - path: daemon_set_doesnt_exist.yaml
+          - path: cm_doesnt_exist.yaml
+

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_required_component_both_requiredTemplate_both_exist.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/reference/metadata_with2templates_required_component_both_requiredTemplate_both_exist.yaml
@@ -1,0 +1,9 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        type: Required
+        requiredTemplates:
+          - path: daemon_set_exists.yaml
+          - path: cm_exists.yaml
+

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/resources/apps.v1.DaemonSet.kube-system.kindnet.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/resources/apps.v1.DaemonSet.kube-system.kindnet.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: SomeNS
+  name: Test1
+  annotations:
+    deprecated.daemonset.template.generation: "1"
+  generation: 1
+  labels:
+    app: kindnet
+    k8s-app: kindnet
+    tier: node
+
+

--- a/pkg/compare/testdata/RefCheckOptionalAndRequired/resources/cm.yaml
+++ b/pkg/compare/testdata/RefCheckOptionalAndRequired/resources/cm.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard


### PR DESCRIPTION
As you can see from the test results anything in optionalTemplates is always optional even when in a required component. Where as if it is in a optional component the requiredTemplates do in fact become required if one exists 
[see here](pkg/compare/testdata/RefCheckOptionalAndRequired/local_with2template_required_component_requiredTemplates_1exists_1doesnt_existout.golden). 