### PR TITLE
Configure dependabot to do go vendoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "gomod" # See documentation for possible values
+    vendor: true
     directories:
       - "/"
       - "addon-tools/*"


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
