### PR TITLE
Revert "Configure dependabot to do go vendoring"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@
 version: 2
 updates:
   - package-ecosystem: "gomod" # See documentation for possible values
-    vendor: true
     directories:
       - "/"
       - "addon-tools/*"


### PR DESCRIPTION
This reverts commit 2ca34908b971c0f00e803433063e40692cbd8fee.
