### PR TITLE
CNF-14097: Count leaves of the patch to find smallest diff

### DIFF
--- a/pkg/compare/testdata/WhenUsingDiffAllFlag-AllUnmatchedResourcesAppearInSummary/localout.golden
+++ b/pkg/compare/testdata/WhenUsingDiffAllFlag-AllUnmatchedResourcesAppearInSummary/localout.golden
@@ -78,5 +78,5 @@ Cluster CRs unmatched to reference CRs: 27
 - apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
 - v1_Service_kubernetes-dashboard_dashboard-metrics-scraper
 - apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
-Metadata Hash: dc922415a44dfdc492ace032becea2d2347eb38a8dbebf76017e70872fc95daf
+Metadata Hash: 81242360f43a42c4b0568cf57a43706bcd8cb4a0b20203f8d36cc31282c2417d
 No patched CRs

--- a/pkg/compare/testdata/WhenUsingDiffAllFlag-AllUnmatchedResourcesAppearInSummary/reference/apps.v1.DaemonSet.kube-system.kindnet.yaml
+++ b/pkg/compare/testdata/WhenUsingDiffAllFlag-AllUnmatchedResourcesAppearInSummary/reference/apps.v1.DaemonSet.kube-system.kindnet.yaml
@@ -4,6 +4,7 @@ metadata:
   namespace: SomeNS
   annotations:
     deprecated.daemonset.template.generation: "1"
+    dont.match.me: "1"
   generation: 1
   labels:
     app: kindnet


### PR DESCRIPTION
In the case where a patch can not be made for one of the templates it will fallback to the old method of counting the number of lines