### PR TITLE
Add downstream container reference

### DIFF
--- a/docs/downstream.md
+++ b/docs/downstream.md
@@ -11,4 +11,21 @@ This build is managed by ART, so most changes need to go through them.
 - [art-dash build status](https://art-dash.engineering.redhat.com/dashboard/build/history?dg_name=kube-compare-artifacts)
 - [brew package](https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=86274)
 - [Errata](https://errata.engineering.redhat.com/package/show/kube-compare-artifacts-container)
-- Downstream container (TBD)
+- [Downstream container](https://catalog.redhat.com/software/containers/openshift4/kube-compare-artifacts-rhel9/66d56abedf3259c57cfc8cba)
+  - Pullspec: registry.redhat.io/openshift4/kube-compare-artifacts-rhel9:latest
+
+## Installing the downstream version of the tool
+
+```bash
+ENGINE=podman # works with "docker" too
+IMAGE=registry.redhat.io/openshift4/kube-compare-artifacts-rhel9:latest
+BASEOS=rhel9 # "rhel8" is an option too, for older systems
+$ENGINE create --name kube-compare "$IMAGE"
+$ENGINE cp "kube-compare:/usr/share/openshift/linux_amd64/kube-compare.$BASEOS" ./kubectl-cluster_compare
+$ENGINE rm -f kube-compare
+sudo install kubectl-cluster_compare /usr/local/bin
+rm kubectl-cluster_compare
+
+# run
+oc cluster-compare -h
+```

--- a/docs/image-build.md
+++ b/docs/image-build.md
@@ -1,7 +1,8 @@
-
 # Kube-compare image build
 
-## Build container
+This image is also distributed in a container build, mostly for Red Hat downstream distribution purposes.
+
+## Building the container
 
 ```bash
 make image-build
@@ -15,15 +16,17 @@ make image-build
 make cross-build
 ```
 
-- Another option is to extract the binary from the container
+## Extracting the tool from the container
 
 ```bash
-docker create --name kube-compare kube-compare:latest
-docker cp kube-compare:/usr/share/openshift/linux_amd64/kube-compare.rhel9 ./kube-compare.rhel9
-docker rm -f kube-compare
+ENGINE=podman # works with "docker" too
+IMAGE=kube-compare:latest
+BASEOS=rhel9 # "rhel8" is an option too, for older systems
+$ENGINE create --name kube-compare "$IMAGE"
+$ENGINE cp "kube-compare:/usr/share/openshift/linux_amd64/kube-compare.$BASEOS" ./kubectl-cluster_compare
+$ENGINE rm -f kube-compare
 
 # run 
 export PATH=$PWD:$PATH
-mv kube-compare.rhel9 kubectl-cluster_compare
 oc cluster-compare -h
 ```


### PR DESCRIPTION
Also updates the image-build and downstream documentation with a
consistent example of installing the tool from the container.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
