### PR TITLE
Add regex inline diff function

### DIFF
--- a/docs/reference-config-guide-v2.md
+++ b/docs/reference-config-guide-v2.md
@@ -344,3 +344,69 @@ metadata:
 ```
 
 you use would use `metadata.annotations."workload.openshift.io/allowed"`.
+
+### PerField Configuration
+
+#### Inline Diff Funcs
+
+This Version of the tool contains builtin Inline diff functions. Inline diff functions are functions that run on a specific
+field in the templates. The functions contain common advanced diff functions that may be also implemented with pure go templating
+but if they were implemented with go templating would result in unclear diff logic that is hard to maintain.
+The functions goal is to enable a more clear and readable usage for common custom templating functions and allow more complex
+functionalities.
+
+To specify an inline function for a specific field yse the `perField` section in the metadata.yaml file as in this example:
+
+```yaml
+apiVersion: v2
+parts:
+- name: ExamplePart
+  components:
+  - name: Example
+    allOf:
+    - path: cm.yaml
+      config:
+        perField:
+        - pathToKey: spec.bigTextBlock # Field in template to run the inline diff function in pathToKey syntax
+          inlineDiffFunc: regex # Inline function 
+```
+
+Supported inline diff functions:
+
+##### Regex Inline Diff Function
+
+The regex Inline diff function allows validating fields in CRs based on a regex. When using the function the command will
+show no diffs in case the cluster CR will match the regex, if it does not match the regex a diff will be shown between the
+cluster CR and the regex expression.
+To use the regex inline diff function you need to enable the regexInline function for the specific field and template in
+the metadata.yaml and also specify the regex inside the template.
+For example:
+
+For a template named cm.yaml where spec.bigTextBlock should be validated by regex:
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  namespace: kubernetes-dashboard
+spec:
+  bigTextBlock: |-
+    This is a big text block with some static content, like this line.
+    It also has a place where (?<username>[a-z0-9]+) would put in their own name. (?<username>[a-z0-9]+) would put in their own name.
+```
+
+the metadata.yaml should contain:
+
+```yaml
+apiVersion: v2
+parts:
+- name: ExamplePart
+  components:
+  - name: Example
+    allOf:
+    - path: cm.yaml
+      config:
+        perField:
+        - pathToKey: spec.bigTextBlock 
+          inlineDiffFunc: regex  
+```

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -494,7 +494,27 @@ func TestCompareRun(t *testing.T) {
 			withSubTestSuffix("One Of").
 			withMetadataFile("metadata-one-of.yaml").
 			withChecks(defaultChecks.withPrefixedSuffix("oneOf")),
-
+		defaultTest("ReferenceV2InlineRegex"),
+		defaultTest("ReferenceV2InlineRegex").
+			withSubTestSuffix("Invalid Regex").
+			withMetadataFile("metadata-invalid-regex.yaml").
+			withChecks(defaultChecks.withPrefixedSuffix("invalidRegex")),
+		defaultTest("ReferenceV2InlineRegex").
+			withSubTestSuffix("With Diff").
+			withMetadataFile("metadata-regex-with-diff.yaml").
+			withChecks(defaultChecks.withPrefixedSuffix("withDiff")),
+		defaultTest("ReferenceV2InlineRegex").
+			withSubTestSuffix("With Diff In First Line").
+			withMetadataFile("metadata-regex-with-diff-in-first-line.yaml").
+			withChecks(defaultChecks.withPrefixedSuffix("WithDiffInFirstLine")),
+		defaultTest("ReferenceV2PerFieldMatcherValidation").
+			withSubTestSuffix("Matcher Does Not exist").
+			withMetadataFile("metadata-does-not-exist.yaml").
+			withChecks(defaultChecks.withPrefixedSuffix("matcherNotExist")),
+		defaultTest("ReferenceV2PerFieldMatcherValidation").
+			withSubTestSuffix("pathToKey Does Not Exist In Template").
+			withMetadataFile("metadata-path-does-not-exist-in-template.yaml").
+			withChecks(defaultChecks.withPrefixedSuffix("pathNotItTemplate")),
 		defaultTest("All Required Templates Exist And There Are No Diffs").
 			withSubTestSuffix("Bad API Resources").
 			withBadAPIResources().

--- a/pkg/compare/parsing.go
+++ b/pkg/compare/parsing.go
@@ -35,6 +35,7 @@ type ReferenceTemplate interface {
 type TemplateConfig interface {
 	GetAllowMerge() bool
 	GetFieldsToOmitRefs() []string
+	GetInlineDiffFuncs() map[string]inlineDiffType
 }
 
 type FieldsToOmit interface {

--- a/pkg/compare/referenceV1.go
+++ b/pkg/compare/referenceV1.go
@@ -193,6 +193,10 @@ func (config ReferenceTemplateConfigV1) GetAllowMerge() bool {
 	return config.AllowMerge
 }
 
+func (config ReferenceTemplateConfigV1) GetInlineDiffFuncs() map[string]inlineDiffType {
+	return map[string]inlineDiffType{}
+}
+
 func (config ReferenceTemplateConfigV1) GetFieldsToOmitRefs() []string {
 	return config.FieldsToOmitRefs
 }
@@ -299,16 +303,20 @@ func (p *ManifestPathV1) Process() error {
 	if len(p.parts) > 0 {
 		return nil
 	}
+	var err error
+	p.parts, err = pathToList(p.PathToKey)
+	return err
+}
 
-	pathToKey, _ := strings.CutPrefix(p.PathToKey, ".")
+func pathToList(path string) ([]string, error) {
+	pathToKey, _ := strings.CutPrefix(path, ".")
 	r := csv.NewReader(strings.NewReader(pathToKey))
 	r.Comma = '.'
 	fields, err := r.Read()
 	if err != nil {
-		return fmt.Errorf("failed to parse path: %w", err)
+		return nil, fmt.Errorf("failed to parse path: %w", err)
 	}
-	p.parts = fields
-	return nil
+	return fields, nil
 }
 
 func ParseV1Templates(ref *ReferenceV1, fsys fs.FS) ([]ReferenceTemplate, error) {

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/localWithDiffInFirstLineerr.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/localWithDiffInFirstLineerr.golden
@@ -1,0 +1,2 @@
+
+error code:1

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/localWithDiffInFirstLineout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/localWithDiffInFirstLineout.golden
@@ -1,0 +1,24 @@
+**********************************
+
+Cluster CR: v1_ConfigMap_kubernetes-dashboard_kubernetes-dashboard-settings
+Reference File: cm-regex-with-diff-in-first-line.yaml
+Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings
+--- TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings	DATE
++++ TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings	DATE
+@@ -7,5 +7,5 @@
+   namespace: kubernetes-dashboard
+ spec:
+   bigTextBlock: |-
+-    This is a big text block with some static content, like this line
+-    It also has a place where (?<username>[a-z0-9]+) would put in their own name. (?<username>[a-z0-9]+) would put in their own name.
++    This is a big text block with some static content, like this line.
++    It also has a place where exampleuser would put in their own name. exampleuser would put in their own name.
+
+**********************************
+
+Summary
+CRs with diffs: 1/1
+No validation issues with the cluster
+No CRs are unmatched to reference CRs
+Metadata Hash: b2cafdff9a5edf9a9f3c6640345e541d456d8130b215a19a4847271563b87ea2
+No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/localinvalidRegexerr.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/localinvalidRegexerr.golden
@@ -1,0 +1,2 @@
+error: reference contains template with config per field with InlineDiffFunc that fails validation. InlineDiffFunc: regex. error: invalid regex passed to inline rgegex diff function: error parsing regexp: invalid named capture: `(?<username[a-z0-9]+) would put in their own name. (?<username>`
+error code:2

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/localout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/localout.golden
@@ -1,0 +1,6 @@
+Summary
+CRs with diffs: 0/1
+No validation issues with the cluster
+No CRs are unmatched to reference CRs
+Metadata Hash: 476e9f99ac24bc2d0b6358cd40a769160d8f4832f2beca4298a31dcc9eb5d49b
+No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/localwithDifferr.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/localwithDifferr.golden
@@ -1,0 +1,2 @@
+
+error code:1

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/localwithDiffout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/localwithDiffout.golden
@@ -1,0 +1,22 @@
+**********************************
+
+Cluster CR: v1_ConfigMap_kubernetes-dashboard_kubernetes-dashboard-settings
+Reference File: cm-regex-with-diff.yaml
+Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings
+--- TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings	DATE
++++ TEMP/v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings	DATE
+@@ -8,4 +8,4 @@
+ spec:
+   bigTextBlock: |-
+     This is a big text block with some static content, like this line.
+-    It also has a place where (?<username>[0-9]+) would put in their own name. (?<username>[0-9]+) would put in their own name.
++    It also has a place where exampleuser would put in their own name. exampleuser would put in their own name.
+
+**********************************
+
+Summary
+CRs with diffs: 1/1
+No validation issues with the cluster
+No CRs are unmatched to reference CRs
+Metadata Hash: 2966b27f0a4b3f5cb43189b61a8d129ffd2f4006dc1bea20df4d9b456a0957ec
+No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/reference/cm-invalidregex.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/reference/cm-invalidregex.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard
+spec:
+  bigTextBlock: |-
+    This is a big text block with some static content, like this line.
+    It also has a place where (?<username[a-z0-9]+) would put in their own name. (?<username>[a-z0-9]+) would put in their own name.

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/reference/cm-regex-with-diff-in-first-line.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/reference/cm-regex-with-diff-in-first-line.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard
+spec:
+  bigTextBlock: |-
+    This is a big text block with some static content, like this line
+    It also has a place where (?<username>[a-z0-9]+) would put in their own name. (?<username>[a-z0-9]+) would put in their own name.

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/reference/cm-regex-with-diff.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/reference/cm-regex-with-diff.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard
+spec:
+  bigTextBlock: |-
+    This is a big text block with some static content, like this line.
+    It also has a place where (?<username>[0-9]+) would put in their own name. (?<username>[0-9]+) would put in their own name.

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/reference/cm.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/reference/cm.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard
+spec:
+  bigTextBlock: |-
+    This is a big text block with some static content, like this line.
+    It also has a place where (?<username>[a-z0-9]+) would put in their own name. (?<username>[a-z0-9]+) would put in their own name.

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/reference/metadata-invalid-regex.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/reference/metadata-invalid-regex.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        allOf:
+          - path: cm-invalidregex.yaml
+            config:
+                perField:
+                - pathToKey: spec.bigTextBlock
+                  inlineDiffFunc: regex

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/reference/metadata-regex-with-diff-in-first-line.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/reference/metadata-regex-with-diff-in-first-line.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        allOf:
+          - path: cm-regex-with-diff-in-first-line.yaml
+            config:
+                perField:
+                - pathToKey: spec.bigTextBlock
+                  inlineDiffFunc: regex

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/reference/metadata-regex-with-diff.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/reference/metadata-regex-with-diff.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        allOf:
+          - path: cm-regex-with-diff.yaml
+            config:
+                perField:
+                - pathToKey: spec.bigTextBlock
+                  inlineDiffFunc: regex

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/reference/metadata.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/reference/metadata.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        allOf:
+          - path: cm.yaml
+            config:
+                perField:
+                - pathToKey: spec.bigTextBlock
+                  inlineDiffFunc: regex

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/resources/cm.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/resources/cm.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard
+spec:
+  bigTextBlock: |-
+    This is a big text block with some static content, like this line.
+    It also has a place where exampleuser would put in their own name. exampleuser would put in their own name.

--- a/pkg/compare/testdata/ReferenceV2PerFieldMatcherValidation/localmatcherNotExisterr.golden
+++ b/pkg/compare/testdata/ReferenceV2PerFieldMatcherValidation/localmatcherNotExisterr.golden
@@ -1,0 +1,2 @@
+error: reference contains template with config per field with InlineDiffFunc that does not exist. InlineDiffFunc: rege
+error code:2

--- a/pkg/compare/testdata/ReferenceV2PerFieldMatcherValidation/localpathNotItTemplateerr.golden
+++ b/pkg/compare/testdata/ReferenceV2PerFieldMatcherValidation/localpathNotItTemplateerr.golden
@@ -1,0 +1,2 @@
+error: reference contains template with config per field with pathToKey that points to a path that does not exist in the template. path: spec.bigTextBloc
+error code:2

--- a/pkg/compare/testdata/ReferenceV2PerFieldMatcherValidation/reference/cm.yaml
+++ b/pkg/compare/testdata/ReferenceV2PerFieldMatcherValidation/reference/cm.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard
+spec:
+  bigTextBlock: |-
+    This is a big text block with some static content, like this line.
+    It also has a place where (?<username>[a-z0-9]+) would put in their own name. (?<username>[a-z0-9]+) would put in their own name.

--- a/pkg/compare/testdata/ReferenceV2PerFieldMatcherValidation/reference/metadata-does-not-exist.yaml
+++ b/pkg/compare/testdata/ReferenceV2PerFieldMatcherValidation/reference/metadata-does-not-exist.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        allOf:
+          - path: cm.yaml
+            config:
+                perField:
+                - pathToKey: spec.bigTextBlock
+                  inlineDiffFunc: rege

--- a/pkg/compare/testdata/ReferenceV2PerFieldMatcherValidation/reference/metadata-path-does-not-exist-in-template.yaml
+++ b/pkg/compare/testdata/ReferenceV2PerFieldMatcherValidation/reference/metadata-path-does-not-exist-in-template.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        allOf:
+          - path: cm.yaml
+            config:
+                perField:
+                - pathToKey: spec.bigTextBloc
+                  inlineDiffFunc: regex

--- a/pkg/compare/testdata/ReferenceV2PerFieldMatcherValidation/resources/cm.yaml
+++ b/pkg/compare/testdata/ReferenceV2PerFieldMatcherValidation/resources/cm.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard
+spec:
+  bigTextBlock: |-
+    This is a big text block with some static content, like this line.
+    It also has a place where exampleuser would put in their own name. exampleuser would put in their own name.


### PR DESCRIPTION
This update adds the option to include common inline diff
 functions in the tool.  Diff functions may simplify complex 
diff logic, which would be hard to write and read using  regular Go templating and include a more tidy usage.

A new regex inline diff function allows checking fields in cluster resources against a regex pattern. If a  field matches the regex, no diffs are shown; if it doesn’t  match, a diff will highlight the difference. To use this,  enable `regexInline` for the field in `metadata.yaml`
 and add the regex in the template.

([CNF-14934](https://issues.redhat.com//browse/CNF-14934))