### PR TITLE
Omit actual metadata hash from most end-to-end tests to simplify test output comparison

### DIFF
--- a/addon-tools/report-creator/report/create_test.go
+++ b/addon-tools/report-creator/report/create_test.go
@@ -92,8 +92,8 @@ func checkCompatibilityWithCompareOutput(t *testing.T, test Test, update bool) {
 	require.NoError(t, cmpCmd.Flags().Set("recursive", "true"))
 	require.NoError(t, cmpCmd.Flags().Set("output", compare.Json))
 	cmpCmd.Run(cmpCmd, []string{})
-	result := testutils.GetFile(t, test.getJSONPath(), testutils.RemoveInconsistentInfo(t, out.String()), update)
-	require.Equal(t, result, testutils.RemoveInconsistentInfo(t, out.String()))
+	result := testutils.GetFile(t, test.getJSONPath(), testutils.RemoveInconsistentInfo(t, out.String(), testutils.FixupOptions{}), update)
+	require.Equal(t, result, testutils.RemoveInconsistentInfo(t, out.String(), testutils.FixupOptions{}))
 }
 
 func removeInconsistentInfoFromReport(text []byte) string {

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/livebadAPIout.golden
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/livebadAPIout.golden
@@ -3,5 +3,5 @@ Summary
 CRs with diffs: 0/14
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 933892b7ae8a4f5232734acc34f6c93fc223844d836b37af390cfeaecf0b7a99
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/liveout.golden
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/liveout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/14
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 933892b7ae8a4f5232734acc34f6c93fc223844d836b37af390cfeaecf0b7a99
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/localout.golden
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/localout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/27
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 933892b7ae8a4f5232734acc34f6c93fc223844d836b37af390cfeaecf0b7a99
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/localwith_diff_yout.golden
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffs/localwith_diff_yout.golden
@@ -701,5 +701,5 @@ Summary
 CRs with diffs: 0/27
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 933892b7ae8a4f5232734acc34f6c93fc223844d836b37af390cfeaecf0b7a99
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffsRefV2/liveout.golden
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffsRefV2/liveout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/14
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: a79de4c2e84902b9f04017776932b7ef60cde50465b67f8ad29771f6e2910a3f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffsRefV2/localout.golden
+++ b/pkg/compare/testdata/AllRequiredTemplatesExistAndThereAreNoDiffsRefV2/localout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/27
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: a79de4c2e84902b9f04017776932b7ef60cde50465b67f8ad29771f6e2910a3f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/CheckIgnoreUnspecifiedFieldsConfig/localout.golden
+++ b/pkg/compare/testdata/CheckIgnoreUnspecifiedFieldsConfig/localout.golden
@@ -24,5 +24,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 5ff6634ba74ea6557c4ae9ed031f4f5de0fa931be69b0ed3aaa05e49961a20a2
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/CheckMergingDoesNotOverwriteTemplateConfig/localout.golden
+++ b/pkg/compare/testdata/CheckMergingDoesNotOverwriteTemplateConfig/localout.golden
@@ -25,5 +25,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 51affba3833d822d9bf8b9009dfedd481f6cdee17755bd85a91f88f975b2efb1
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/Description/local_component_shown_for_diff_out.golden
+++ b/pkg/compare/testdata/Description/local_component_shown_for_diff_out.golden
@@ -22,5 +22,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: c5cb62eca715b779001572ac1bec4f0d2e803f45be05a265d1bcf526974b21cc
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/Description/local_hidden_for_match_out.golden
+++ b/pkg/compare/testdata/Description/local_hidden_for_match_out.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 31bd82605d29b1d9d7ccf38d445a7a20ec4456e732542cf61677665c25e516cc
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/Description/local_part_shown_for_diff_out.golden
+++ b/pkg/compare/testdata/Description/local_part_shown_for_diff_out.golden
@@ -22,5 +22,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 2234841a2a5d4415d8e201261180b423035b41cef3e626fd3cf130ffb3243401
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/Description/local_precidence_c_t_shown_for_diff_out.golden
+++ b/pkg/compare/testdata/Description/local_precidence_c_t_shown_for_diff_out.golden
@@ -22,5 +22,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: c5cb62eca715b779001572ac1bec4f0d2e803f45be05a265d1bcf526974b21cc
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/Description/local_precidence_p_c_shown_for_diff_out.golden
+++ b/pkg/compare/testdata/Description/local_precidence_p_c_shown_for_diff_out.golden
@@ -22,5 +22,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 9b6434b44dcf6d7e93abcb04e1bc28734b031b59db73213a05e44858d0b76dcc
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/Description/local_precidence_p_c_t_shown_for_diff_out.golden
+++ b/pkg/compare/testdata/Description/local_precidence_p_c_t_shown_for_diff_out.golden
@@ -22,5 +22,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 9b6434b44dcf6d7e93abcb04e1bc28734b031b59db73213a05e44858d0b76dcc
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/Description/local_precidence_p_t_shown_for_diff_out.golden
+++ b/pkg/compare/testdata/Description/local_precidence_p_t_shown_for_diff_out.golden
@@ -22,5 +22,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 2234841a2a5d4415d8e201261180b423035b41cef3e626fd3cf130ffb3243401
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/Description/local_shown_for_diff_out.golden
+++ b/pkg/compare/testdata/Description/local_shown_for_diff_out.golden
@@ -24,5 +24,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: bb7dfc980f720d7f14b3d56d97bd99a354e4bdb2732494a0b703358f3c13406f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/Description/local_shown_for_missing_file_out.golden
+++ b/pkg/compare/testdata/Description/local_shown_for_missing_file_out.golden
@@ -10,5 +10,5 @@ ExamplePart:
         particular CR is required, or add an URL that points at more
         documentation.  It is only shown when a difference is detected.
 No CRs are unmatched to reference CRs
-Metadata Hash: 0fd0aab7eefa0457e1b889b1ba49e12872406547092c5e5ae2b085c916881f35
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/DescriptionV1/local_hidden_for_match_out.golden
+++ b/pkg/compare/testdata/DescriptionV1/local_hidden_for_match_out.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: dfb101d7e388d4da0fe0fcbd51bf789957df7e423d387a2de7f1837e80bbfdf1
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/DescriptionV1/local_shown_for_diff_out.golden
+++ b/pkg/compare/testdata/DescriptionV1/local_shown_for_diff_out.golden
@@ -24,5 +24,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 00e663bde447d905954be98769b010b06c60db09ce4844033469b10aa08acee3
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/DescriptionV1/local_shown_for_missing_file_out.golden
+++ b/pkg/compare/testdata/DescriptionV1/local_shown_for_missing_file_out.golden
@@ -10,5 +10,5 @@ ExamplePart:
         particular CR is required, or add an URL that points at more
         documentation.  It is only shown when a difference is detected.
 No CRs are unmatched to reference CRs
-Metadata Hash: 9f8c42725858a6e34e29463d42cd15c766fb190431abb6d4f9e3237cfbe930dd
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/liveout.golden
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/liveout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/3
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 60bdeb350b156f27e4f9ccbbcd0ae85c821f2329222885d88918f7e5ab8352e3
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/localout.golden
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShown/localout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/3
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 60bdeb350b156f27e4f9ccbbcd0ae85c821f2329222885d88918f7e5ab8352e3
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShownAllQuoted/localout.golden
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShownAllQuoted/localout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/3
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 70045b1d31c7a0149fbfce3d269302d1a6da50d63845d29349cc30cead3b2910
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShownLeadingDot/localout.golden
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShownLeadingDot/localout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/3
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 2eda73a0a87e1336ec7dde9ae02b5e9c2700c228ce425853e44ff9c86470f4b0
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShownNonDefault/localout.golden
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShownNonDefault/localout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/3
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 286d2b5b7be43bd7c5c2e78e735f678ca5140c00a77fcde971ba298910626763
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShownPrefix/localout.golden
+++ b/pkg/compare/testdata/DiffinCustomOmittedFieldsIsntShownPrefix/localout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/3
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 4ecf3285b5da9dec14fa03f1002ea1408c54b7b58d00d015cfb35ed832996765
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/InvalidResourcesAreSkipped/localout.golden
+++ b/pkg/compare/testdata/InvalidResourcesAreSkipped/localout.golden
@@ -31,5 +31,5 @@ ExamplePart:
     Missing CRs:
     - deploymentDashboard.yaml
 No CRs are unmatched to reference CRs
-Metadata Hash: aa4c94f1307788e1da81f57718a9f1364d35d4ff6099fc633724bcf9d051a094
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/MachineConfigsCatchAll/localout.golden
+++ b/pkg/compare/testdata/MachineConfigsCatchAll/localout.golden
@@ -37,5 +37,5 @@ Summary
 CRs with diffs: 1/3
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: ec21daa539ad95e16532a1af08688befe0226f615e27d80399edc6854aec812d
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/liveout.golden
+++ b/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/liveout.golden
@@ -40,5 +40,5 @@ ExamplePart:
     Missing CRs:
     - deploymentDashboard.yaml
 No CRs are unmatched to reference CRs
-Metadata Hash: aa4c94f1307788e1da81f57718a9f1364d35d4ff6099fc633724bcf9d051a094
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/localout.golden
+++ b/pkg/compare/testdata/ManualCorrelationMatchesArePrioritizedOverGroupCorrelation/localout.golden
@@ -40,5 +40,5 @@ ExamplePart:
     Missing CRs:
     - deploymentDashboard.yaml
 No CRs are unmatched to reference CRs
-Metadata Hash: aa4c94f1307788e1da81f57718a9f1364d35d4ff6099fc633724bcf9d051a094
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/NoDiffs/localout.golden
+++ b/pkg/compare/testdata/NoDiffs/localout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/2
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: aa4c94f1307788e1da81f57718a9f1364d35d4ff6099fc633724bcf9d051a094
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/NoDiffs/localwithVebosityFlagout.golden
+++ b/pkg/compare/testdata/NoDiffs/localwithVebosityFlagout.golden
@@ -16,5 +16,5 @@ Summary
 CRs with diffs: 0/2
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: aa4c94f1307788e1da81f57718a9f1364d35d4ff6099fc633724bcf9d051a094
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/liveout.golden
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/liveout.golden
@@ -18,5 +18,5 @@ ExamplePart2:
     Missing CRs:
     - crb.yaml
 No CRs are unmatched to reference CRs
-Metadata Hash: 98dca024e0509f46f0a228da2ad61b98804a3f4b5a7ad1ac31d41b46812c32ea
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/localout.golden
+++ b/pkg/compare/testdata/OnlyRequiredResourcesOfRequiredComponentAreReportedMissing(OptionalResourcesNotReported)/localout.golden
@@ -17,5 +17,5 @@ ExamplePart2:
     Missing CRs:
     - crb.yaml
 No CRs are unmatched to reference CRs
-Metadata Hash: 98dca024e0509f46f0a228da2ad61b98804a3f4b5a7ad1ac31d41b46812c32ea
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/RefContainsTemplatesWithFunctionTemplatesInSameFile/localout.golden
+++ b/pkg/compare/testdata/RefContainsTemplatesWithFunctionTemplatesInSameFile/localout.golden
@@ -20,5 +20,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 65c31424fd7e947b5654739d511a0b4b1a2f16f0a88babfffe12f60a7906e2a3
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/RefTemplateInSubDirNotReportedMissing/liveout.golden
+++ b/pkg/compare/testdata/RefTemplateInSubDirNotReportedMissing/liveout.golden
@@ -20,5 +20,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: daa42611acd8bc86828efa8d13a2c806211f5028d3494c04a8e4b7e9f6d473b9
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/RefTemplateInSubDirNotReportedMissing/localout.golden
+++ b/pkg/compare/testdata/RefTemplateInSubDirNotReportedMissing/localout.golden
@@ -20,5 +20,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: daa42611acd8bc86828efa8d13a2c806211f5028d3494c04a8e4b7e9f6d473b9
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/RefTemplateInSubDirWorksWithManualCorrelation/liveout.golden
+++ b/pkg/compare/testdata/RefTemplateInSubDirWorksWithManualCorrelation/liveout.golden
@@ -36,5 +36,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 8a6eae9d27c09d5d41340286ded1021896fc13b178f34b32905c68e920f2d81d
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/RefTemplateInSubDirWorksWithManualCorrelation/localout.golden
+++ b/pkg/compare/testdata/RefTemplateInSubDirWorksWithManualCorrelation/localout.golden
@@ -36,5 +36,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 8a6eae9d27c09d5d41340286ded1021896fc13b178f34b32905c68e920f2d81d
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/RefWithTemplateFunctionsRendersAsExpected/liveout.golden
+++ b/pkg/compare/testdata/RefWithTemplateFunctionsRendersAsExpected/liveout.golden
@@ -20,5 +20,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 013675dbf39d109d2e17bef23e4786717e5439e5490cf20853af5481f0818c40
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/RefWithTemplateFunctionsRendersAsExpected/localout.golden
+++ b/pkg/compare/testdata/RefWithTemplateFunctionsRendersAsExpected/localout.golden
@@ -20,5 +20,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 013675dbf39d109d2e17bef23e4786717e5439e5490cf20853af5481f0818c40
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceHasValidVersion/localout.golden
+++ b/pkg/compare/testdata/ReferenceHasValidVersion/localout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: f5e1eb9b990e18e6ce2cf9a939c99909a29f8afbfff2fda0f3b539bb1fdc6adc
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2All/localallOfout.golden
+++ b/pkg/compare/testdata/ReferenceV2All/localallOfout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/27
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: a79de4c2e84902b9f04017776932b7ef60cde50465b67f8ad29771f6e2910a3f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2All/localallOrNoneOfout.golden
+++ b/pkg/compare/testdata/ReferenceV2All/localallOrNoneOfout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/27
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: a79de4c2e84902b9f04017776932b7ef60cde50465b67f8ad29771f6e2910a3f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2All/localanyOfout.golden
+++ b/pkg/compare/testdata/ReferenceV2All/localanyOfout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/27
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: a79de4c2e84902b9f04017776932b7ef60cde50465b67f8ad29771f6e2910a3f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2All/localanyOneOfout.golden
+++ b/pkg/compare/testdata/ReferenceV2All/localanyOneOfout.golden
@@ -16,5 +16,5 @@ ExamplePart:
     - secret.yaml
     - service.yaml
 No CRs are unmatched to reference CRs
-Metadata Hash: a79de4c2e84902b9f04017776932b7ef60cde50465b67f8ad29771f6e2910a3f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2All/localnoneOfout.golden
+++ b/pkg/compare/testdata/ReferenceV2All/localnoneOfout.golden
@@ -16,5 +16,5 @@ ExamplePart:
     - secret.yaml
     - service.yaml
 No CRs are unmatched to reference CRs
-Metadata Hash: a79de4c2e84902b9f04017776932b7ef60cde50465b67f8ad29771f6e2910a3f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2All/localoneOfout.golden
+++ b/pkg/compare/testdata/ReferenceV2All/localoneOfout.golden
@@ -16,5 +16,5 @@ ExamplePart:
     - secret.yaml
     - service.yaml
 No CRs are unmatched to reference CRs
-Metadata Hash: a79de4c2e84902b9f04017776932b7ef60cde50465b67f8ad29771f6e2910a3f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2DiffinCustomOmittedFieldsIsntShown/local_basic_include_out.golden
+++ b/pkg/compare/testdata/ReferenceV2DiffinCustomOmittedFieldsIsntShown/local_basic_include_out.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/3
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: d1b43073d9263292a98639abf0845c1f68a53f21a210429b1a71d3b8b47b4d14
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2DiffinCustomOmittedFieldsIsntShown/local_basic_out.golden
+++ b/pkg/compare/testdata/ReferenceV2DiffinCustomOmittedFieldsIsntShown/local_basic_out.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/3
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: aec723b5a3f391084f76a8815354719badc5306910b6025df025ed535b6ecead
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2DiffinCustomOmittedFieldsIsntShown/local_leading_dot_out.golden
+++ b/pkg/compare/testdata/ReferenceV2DiffinCustomOmittedFieldsIsntShown/local_leading_dot_out.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/3
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 8f628171c03544439e58089ab3c89e3adbe1534287e505fde2add79db82cca96
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2DiffinCustomOmittedFieldsIsntShown/local_non_default_out.golden
+++ b/pkg/compare/testdata/ReferenceV2DiffinCustomOmittedFieldsIsntShown/local_non_default_out.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/3
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: aefa16fbc84fb41ae77b36a53637b0a4e5147ddcbb892d8bfa877080714b4c0e
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2DiffinCustomOmittedFieldsIsntShown/local_quoted_out.golden
+++ b/pkg/compare/testdata/ReferenceV2DiffinCustomOmittedFieldsIsntShown/local_quoted_out.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/3
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: b276bc9ca9b157818bea3e7a6747c0c6acaa2dfbeb9bfe8dab6ec9b00d8a843d
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2DiffinCustomOmittedFieldsIsntShownPrefix/localout.golden
+++ b/pkg/compare/testdata/ReferenceV2DiffinCustomOmittedFieldsIsntShownPrefix/localout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/3
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: b80b0a79f9e28d35f5668c992fac504986bd4bd4e49149f1583c5e12ca340cef
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffBetweenCapturegroupsout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffBetweenCapturegroupsout.golden
@@ -19,5 +19,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 8dc383ef1094f008b5964b1cd7359cbed7d9aa0803b0e5c0732292234575c01f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffInFirstLineout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffInFirstLineout.golden
@@ -20,5 +20,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 28c5a8aaf899f69e286d1490a1677bf733f66faaa0d3f074fb839f885438acf1
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithMismatchedCapturegroupsout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithMismatchedCapturegroupsout.golden
@@ -22,5 +22,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 8637821fdd401fb34334081e00db1c39a8270ad349e80e081ee9a0a60c0726e4
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localinvalidCapturegroupsLateDetectionout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localinvalidCapturegroupsLateDetectionout.golden
@@ -9,5 +9,5 @@ ExamplePart:
     - cm-invalid-capturegroups-late-detection.yaml
 Cluster CRs unmatched to reference CRs: 1
 - v1_ConfigMap_kubernetes-dashboard_kubernetes-dashboard-settings
-Metadata Hash: 7c1ce6a7980e19c76ccdeb0103b98b0c36d66b43b13de79d6a669dd1ee8af0e1
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: ff9ab68ef48d94d9a1c8385a5cf8be657fb76ce0ccde7ed416f4d43870c2b9d1
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localwithDiffout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localwithDiffout.golden
@@ -19,5 +19,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: e7ef65b0bc5825001bbbc84b3a8f551e96a91ca9e1ba7b8ae4c75e68a6344ae3
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/localWithDiffInFirstLineout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/localWithDiffInFirstLineout.golden
@@ -20,5 +20,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: cddaf3aee6ceb9831fe879977e864aeddf017acaa7a7a32a3d376bd84d9857f9
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/localout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/localout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 476e9f99ac24bc2d0b6358cd40a769160d8f4832f2beca4298a31dcc9eb5d49b
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineRegex/localwithDiffout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineRegex/localwithDiffout.golden
@@ -18,5 +18,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 2966b27f0a4b3f5cb43189b61a8d129ffd2f4006dc1bea20df4d9b456a0957ec
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2OnlyOne/localallOfout.golden
+++ b/pkg/compare/testdata/ReferenceV2OnlyOne/localallOfout.golden
@@ -15,5 +15,5 @@ ExamplePart:
     - secret.yaml
     - service.yaml
 No CRs are unmatched to reference CRs
-Metadata Hash: a79de4c2e84902b9f04017776932b7ef60cde50465b67f8ad29771f6e2910a3f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2OnlyOne/localallOrNoneOfout.golden
+++ b/pkg/compare/testdata/ReferenceV2OnlyOne/localallOrNoneOfout.golden
@@ -15,5 +15,5 @@ ExamplePart:
     - secret.yaml
     - service.yaml
 No CRs are unmatched to reference CRs
-Metadata Hash: a79de4c2e84902b9f04017776932b7ef60cde50465b67f8ad29771f6e2910a3f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2OnlyOne/localanyOfout.golden
+++ b/pkg/compare/testdata/ReferenceV2OnlyOne/localanyOfout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: a79de4c2e84902b9f04017776932b7ef60cde50465b67f8ad29771f6e2910a3f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2OnlyOne/localanyOneOfout.golden
+++ b/pkg/compare/testdata/ReferenceV2OnlyOne/localanyOneOfout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: a79de4c2e84902b9f04017776932b7ef60cde50465b67f8ad29771f6e2910a3f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2OnlyOne/localnoneOfout.golden
+++ b/pkg/compare/testdata/ReferenceV2OnlyOne/localnoneOfout.golden
@@ -6,5 +6,5 @@ ExamplePart:
     These should not have been matched:
     - cm.yaml
 No CRs are unmatched to reference CRs
-Metadata Hash: a79de4c2e84902b9f04017776932b7ef60cde50465b67f8ad29771f6e2910a3f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/ReferenceV2OnlyOne/localoneOfout.golden
+++ b/pkg/compare/testdata/ReferenceV2OnlyOne/localoneOfout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: a79de4c2e84902b9f04017776932b7ef60cde50465b67f8ad29771f6e2910a3f
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/liveout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/liveout.golden
@@ -3,5 +3,5 @@ Summary
 CRs with diffs: 0/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 020bf68cdd83ffd79e552879bf4b89b3e466100260a21b9d91b839373fa0b439
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/localout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreNotReportedMissing/localout.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 020bf68cdd83ffd79e552879bf4b89b3e466100260a21b9d91b839373fa0b439
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/liveout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/liveout.golden
@@ -7,5 +7,5 @@ ExamplePart1:
     Missing CRs:
     - cm.yaml
 No CRs are unmatched to reference CRs
-Metadata Hash: d050e3182f5aa23fb2082c4f5642e1f5d32a8870cc151178ebd8ce95b4297783
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/localout.golden
+++ b/pkg/compare/testdata/RequiredResourcesOfOptionalComponentAreReportedMissingIfAtLeastOneOfResourcesInGroupIsIncluded/localout.golden
@@ -6,5 +6,5 @@ ExamplePart1:
     Missing CRs:
     - cm.yaml
 No CRs are unmatched to reference CRs
-Metadata Hash: d050e3182f5aa23fb2082c4f5642e1f5d32a8870cc151178ebd8ce95b4297783
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/SomeDiffs/localwithVebosityFlagout.golden
+++ b/pkg/compare/testdata/SomeDiffs/localwithVebosityFlagout.golden
@@ -27,5 +27,5 @@ Summary
 CRs with diffs: 1/2
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: aa4c94f1307788e1da81f57718a9f1364d35d4ff6099fc633724bcf9d051a094
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/SomeDiffs/localwith_diff_yout.golden
+++ b/pkg/compare/testdata/SomeDiffs/localwith_diff_yout.golden
@@ -127,5 +127,5 @@ Summary
 CRs with diffs: 1/2
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: aa4c94f1307788e1da81f57718a9f1364d35d4ff6099fc633724bcf9d051a094
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/TemplatesContainKindThatIsNotRecognizableInLiveCluster/liveout.golden
+++ b/pkg/compare/testdata/TemplatesContainKindThatIsNotRecognizableInLiveCluster/liveout.golden
@@ -7,5 +7,5 @@ ExamplePart:
     Missing CRs:
     - apps.v1.KindNotSupportedByCluster.kube-system.kindnet.yaml
 No CRs are unmatched to reference CRs
-Metadata Hash: 346f1088e461ee2dcf93e6427a4f8bafee885e0998b2c5891b2023074decd482
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localout.golden
@@ -19,5 +19,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: e4a0c8433c5a751d41ebe85fceb11cb225dcd771f1c450818ff4cd1738f0b2bc
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localout.golden
@@ -3,5 +3,5 @@ Summary
 CRs with diffs: 0/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 2a036377d67f5dc215bf351f995a791aa4c3b6900f1fd1e44b914008c476b91b
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/UserOverride/localexactMatchout.golden
+++ b/pkg/compare/testdata/UserOverride/localexactMatchout.golden
@@ -55,5 +55,5 @@ Summary
 CRs with diffs: 2/2
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 52a09a3286d1413894db4a734a14b05bb77ea4d739744bd699fc447194ece3e1
+Metadata Hash: $METADATA_HASH$
 Cluster CRs with patches applied: 1

--- a/pkg/compare/testdata/UserOverride/localgotemplateout.golden
+++ b/pkg/compare/testdata/UserOverride/localgotemplateout.golden
@@ -45,5 +45,5 @@ Summary
 CRs with diffs: 1/2
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 52a09a3286d1413894db4a734a14b05bb77ea4d739744bd699fc447194ece3e1
+Metadata Hash: $METADATA_HASH$
 Cluster CRs with patches applied: 1

--- a/pkg/compare/testdata/UserOverride/localrfc6902out.golden
+++ b/pkg/compare/testdata/UserOverride/localrfc6902out.golden
@@ -45,5 +45,5 @@ Summary
 CRs with diffs: 1/2
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 52a09a3286d1413894db4a734a14b05bb77ea4d739744bd699fc447194ece3e1
+Metadata Hash: $METADATA_HASH$
 Cluster CRs with patches applied: 1

--- a/pkg/compare/testdata/UserOverride/localsuccessfulout.golden
+++ b/pkg/compare/testdata/UserOverride/localsuccessfulout.golden
@@ -45,5 +45,5 @@ Summary
 CRs with diffs: 1/2
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 52a09a3286d1413894db4a734a14b05bb77ea4d739744bd699fc447194ece3e1
+Metadata Hash: $METADATA_HASH$
 Cluster CRs with patches applied: 1

--- a/pkg/compare/testdata/WhenUsingDiffAllFlag-AllUnmatchedResourcesAppearInSummary/localout.golden
+++ b/pkg/compare/testdata/WhenUsingDiffAllFlag-AllUnmatchedResourcesAppearInSummary/localout.golden
@@ -78,5 +78,5 @@ Cluster CRs unmatched to reference CRs: 27
 - apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
 - v1_Service_kubernetes-dashboard_dashboard-metrics-scraper
 - apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
-Metadata Hash: 81242360f43a42c4b0568cf57a43706bcd8cb4a0b20203f8d36cc31282c2417d
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/semver/local_bad_version_out.golden
+++ b/pkg/compare/testdata/semver/local_bad_version_out.golden
@@ -21,5 +21,5 @@ Summary
 CRs with diffs: 1/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: ab326d51f12973acddecec54bb524924adce2d3bac1e16ef3c21f2f62a8cd899
+Metadata Hash: $METADATA_HASH$
 No patched CRs

--- a/pkg/compare/testdata/semver/local_good_version_out.golden
+++ b/pkg/compare/testdata/semver/local_good_version_out.golden
@@ -2,5 +2,5 @@ Summary
 CRs with diffs: 0/1
 No validation issues with the cluster
 No CRs are unmatched to reference CRs
-Metadata Hash: 8d93168fbae356a1ec07de7eed701b2bdbe4931fb73140f875b9ae34aac48b6a
+Metadata Hash: $METADATA_HASH$
 No patched CRs


### PR DESCRIPTION
Signed-off-by: Jim Ramsay <jramsay@redhat.com>
