### PR TITLE
CNF-15603: Corellate capture groups across objects

### DIFF
--- a/pkg/compare/capturegroupsInlineDiff.go
+++ b/pkg/compare/capturegroupsInlineDiff.go
@@ -270,12 +270,12 @@ func (id *diffInfo) comparableDiffPair(i int) (*diffmatchpatch.Diff, *diffmatchp
 }
 
 // Main entrypoint called by compare.go
-func (id CapturegroupsInlineDiff) Diff(pattern, value string) string {
+func (id CapturegroupsInlineDiff) Diff(pattern, value string, sharedCapturedValues CapturedValues) (string, CapturedValues) {
 	// General approach:
 	//  - Match all relevant capturegroups
 	//  - Substitute in the values for all matched capturegroups to the pattern
 
-	cgDiff := diffInfo{CapturedValues: CapturedValues{caps: make(map[string][]string)}}
+	cgDiff := diffInfo{CapturedValues: sharedCapturedValues}
 
 	// Doing a word-wise diff shrinks the probleset by avoiding any text that
 	// is identical or an obvious plain deletion or addition.
@@ -328,7 +328,7 @@ func (id CapturegroupsInlineDiff) Diff(pattern, value string) string {
 	// matched at different points
 	reconciledString += cgDiff.getWarnings()
 
-	return reconciledString
+	return reconciledString, cgDiff.CapturedValues
 }
 
 // Validation entrypoint called by referenceV2.go

--- a/pkg/compare/capturegroupsInlineDiff_test.go
+++ b/pkg/compare/capturegroupsInlineDiff_test.go
@@ -142,7 +142,7 @@ func TestCapturegroupsDiff(t *testing.T) {
 					expected: []string{"one", "two", "three"},
 					expectedCg: CapturedValues{
 						caps: map[string][]string{
-							"g1": []string{"two"},
+							"g1": {"two"},
 						},
 					},
 				},
@@ -167,7 +167,7 @@ func TestCapturegroupsDiff(t *testing.T) {
 					expected: []string{"one", "two point five", "three"},
 					expectedCg: CapturedValues{
 						caps: map[string][]string{
-							"g1": []string{"two point five"},
+							"g1": {"two point five"},
 						},
 					},
 				},
@@ -203,8 +203,8 @@ func TestCapturegroupsDiff(t *testing.T) {
 					expected: []string{"Line one", "Line a two b", "Line three"},
 					expectedCg: CapturedValues{
 						caps: map[string][]string{
-							"g1": []string{"a"},
-							"g2": []string{"b"},
+							"g1": {"a"},
+							"g2": {"b"},
 						},
 					},
 				},
@@ -214,8 +214,8 @@ func TestCapturegroupsDiff(t *testing.T) {
 					expected: []string{"Line one", "Line a a a two b", "Line three"},
 					expectedCg: CapturedValues{
 						caps: map[string][]string{
-							"g1": []string{"a a a"},
-							"g2": []string{"b"},
+							"g1": {"a a a"},
+							"g2": {"b"},
 						},
 					},
 				},
@@ -231,7 +231,7 @@ func TestCapturegroupsDiff(t *testing.T) {
 					expected: []string{"Line one", "Line a a two a a", "Line a a"},
 					expectedCg: CapturedValues{
 						caps: map[string][]string{
-							"g1": []string{"a a"},
+							"g1": {"a a"},
 						},
 					},
 				},
@@ -243,7 +243,7 @@ func TestCapturegroupsDiff(t *testing.T) {
 					},
 					expectedCg: CapturedValues{
 						caps: map[string][]string{
-							"g1": []string{"a a", "b", "three"},
+							"g1": {"a a", "b", "three"},
 						},
 					},
 				},
@@ -255,12 +255,12 @@ func TestCapturegroupsDiff(t *testing.T) {
 					},
 					initialCg: CapturedValues{
 						caps: map[string][]string{
-							"g1": []string{"previous"},
+							"g1": {"previous"},
 						},
 					},
 					expectedCg: CapturedValues{
 						caps: map[string][]string{
-							"g1": []string{"previous", "a a"},
+							"g1": {"previous", "a a"},
 						},
 					},
 				},
@@ -276,9 +276,9 @@ func TestCapturegroupsDiff(t *testing.T) {
 					expected: []string{"Hello Wello"},
 					expectedCg: CapturedValues{
 						caps: map[string][]string{
-							"hello":  []string{"Hello"},
-							"world":  []string{"Wello"},
-							"nested": []string{"ello"},
+							"hello":  {"Hello"},
+							"world":  {"Wello"},
+							"nested": {"ello"},
 						},
 					},
 				},
@@ -288,9 +288,9 @@ func TestCapturegroupsDiff(t *testing.T) {
 					expected: []string{"Hello World", "WARNING: Capturegroup (?<nested>…) matched multiple values: « ello | orld »"},
 					expectedCg: CapturedValues{
 						caps: map[string][]string{
-							"hello":  []string{"Hello"},
-							"world":  []string{"World"},
-							"nested": []string{"ello", "orld"},
+							"hello":  {"Hello"},
+							"world":  {"World"},
+							"nested": {"ello", "orld"},
 						},
 					},
 				},

--- a/pkg/compare/capturegroupsInlineDiff_test.go
+++ b/pkg/compare/capturegroupsInlineDiff_test.go
@@ -77,9 +77,11 @@ func mlString(lines []string) string {
 
 func TestCapturegroupsDiff(t *testing.T) {
 	type Case struct {
-		message  string
-		value    []string
-		expected []string
+		message    string
+		value      []string
+		expected   []string
+		initialCg  CapturedValues
+		expectedCg CapturedValues
 	}
 	suites := []struct {
 		message string
@@ -138,6 +140,11 @@ func TestCapturegroupsDiff(t *testing.T) {
 					message:  "matching pattern",
 					value:    []string{"one", "two", "three"},
 					expected: []string{"one", "two", "three"},
+					expectedCg: CapturedValues{
+						caps: map[string][]string{
+							"g1": []string{"two"},
+						},
+					},
 				},
 			},
 		},
@@ -158,6 +165,11 @@ func TestCapturegroupsDiff(t *testing.T) {
 					message:  "matching pattern",
 					value:    []string{"one", "two point five", "three"},
 					expected: []string{"one", "two point five", "three"},
+					expectedCg: CapturedValues{
+						caps: map[string][]string{
+							"g1": []string{"two point five"},
+						},
+					},
 				},
 			},
 		},
@@ -189,11 +201,23 @@ func TestCapturegroupsDiff(t *testing.T) {
 					message:  "matching pattern",
 					value:    []string{"Line one", "Line a two b", "Line three"},
 					expected: []string{"Line one", "Line a two b", "Line three"},
+					expectedCg: CapturedValues{
+						caps: map[string][]string{
+							"g1": []string{"a"},
+							"g2": []string{"b"},
+						},
+					},
 				},
 				{
 					message:  "matching pattern with spaces",
 					value:    []string{"Line one", "Line a a a two b", "Line three"},
 					expected: []string{"Line one", "Line a a a two b", "Line three"},
+					expectedCg: CapturedValues{
+						caps: map[string][]string{
+							"g1": []string{"a a a"},
+							"g2": []string{"b"},
+						},
+					},
 				},
 			},
 		},
@@ -205,12 +229,39 @@ func TestCapturegroupsDiff(t *testing.T) {
 					message:  "matching pattern identically",
 					value:    []string{"Line one", "Line a a two a a", "Line a a"},
 					expected: []string{"Line one", "Line a a two a a", "Line a a"},
+					expectedCg: CapturedValues{
+						caps: map[string][]string{
+							"g1": []string{"a a"},
+						},
+					},
 				},
 				{
 					message: "matching pattern differently each time",
 					value:   []string{"Line one", "Line a a two b", "Line three"},
 					expected: []string{"Line one", "Line (?<g1>=a a) two (?<g1>=a a)", "Line (?<g1>=a a)",
 						"WARNING: Capturegroup (?<g1>…) matched multiple values: « a a | b | three »",
+					},
+					expectedCg: CapturedValues{
+						caps: map[string][]string{
+							"g1": []string{"a a", "b", "three"},
+						},
+					},
+				},
+				{
+					message: "mismatched capturegroups from incoming shared captures",
+					value:   []string{"Line one", "Line a a two a a", "Line a a"},
+					expected: []string{"Line one", "Line (?<g1>=previous) two (?<g1>=previous)", "Line (?<g1>=previous)",
+						"WARNING: Capturegroup (?<g1>…) matched multiple values: « previous | a a »",
+					},
+					initialCg: CapturedValues{
+						caps: map[string][]string{
+							"g1": []string{"previous"},
+						},
+					},
+					expectedCg: CapturedValues{
+						caps: map[string][]string{
+							"g1": []string{"previous", "a a"},
+						},
 					},
 				},
 			},
@@ -223,11 +274,25 @@ func TestCapturegroupsDiff(t *testing.T) {
 					message:  "matching sub pattern",
 					value:    []string{"Hello Wello"},
 					expected: []string{"Hello Wello"},
+					expectedCg: CapturedValues{
+						caps: map[string][]string{
+							"hello":  []string{"Hello"},
+							"world":  []string{"Wello"},
+							"nested": []string{"ello"},
+						},
+					},
 				},
 				{
 					message:  "different sub pattern",
 					value:    []string{"Hello World"},
 					expected: []string{"Hello World", "WARNING: Capturegroup (?<nested>…) matched multiple values: « ello | orld »"},
+					expectedCg: CapturedValues{
+						caps: map[string][]string{
+							"hello":  []string{"Hello"},
+							"world":  []string{"World"},
+							"nested": []string{"ello", "orld"},
+						},
+					},
 				},
 			},
 		},
@@ -237,8 +302,9 @@ func TestCapturegroupsDiff(t *testing.T) {
 			for _, c := range s.cases {
 				t.Run(c.message, func(t *testing.T) {
 					cg := CapturegroupsInlineDiff{}
-					actual := cg.Diff(mlString(s.pattern), mlString(c.value))
+					actual, resultingCg := cg.Diff(mlString(s.pattern), mlString(c.value), c.initialCg)
 					assert.Equal(t, mlString(c.expected), actual)
+					assert.Equal(t, c.expectedCg, resultingCg)
 				})
 			}
 		})

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -821,8 +821,26 @@ func (e InlineDiffError) Error() string {
 
 func (obj InfoObject) runInlineDiffFuncs() error {
 	var errs []error
+
+	// Sort the configured paths for reproducibility
+	sortedPaths := make([]string, 0, len(obj.templateFieldConf))
+	for pathToKey := range obj.templateFieldConf {
+		sortedPaths = append(sortedPaths, pathToKey)
+	}
+	slices.Sort(sortedPaths)
+
+	// Pass 1: Verify the DiffFn and record any capturegroup matches
+	type DiffValues struct {
+		value        string
+		clusterValue string
+		listedPath   []string
+		pathToKey    string
+		diffFn       InlineDiff
+	}
+	preprocessedValues := make([]DiffValues, 0, len(obj.templateFieldConf))
 	sharedCapturegroups := CapturedValues{}
-	for pathToKey, inlineDiffFunc := range obj.templateFieldConf {
+	for _, pathToKey := range sortedPaths {
+		inlineDiffFunc := obj.templateFieldConf[pathToKey]
 		listedPath, err := pathToList(pathToKey)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to parse path of field %s that uses inline diff func: %w", pathToKey, err))
@@ -851,11 +869,24 @@ func (obj InfoObject) runInlineDiffFuncs() error {
 			errs = append(errs, fmt.Errorf("failed to validate the inline diff for field %s, %w", pathToKey, err))
 			continue
 		}
-		patchedString, updatedCapturegroups := diffFn.Diff(value, clusterValue, sharedCapturegroups)
+		_, updatedCapturegroups := diffFn.Diff(value, clusterValue, sharedCapturegroups)
 		sharedCapturegroups = updatedCapturegroups
-		err = SetNestedString(obj.injectedObjFromTemplate.Object, patchedString, listedPath...)
+		preprocessedValues = append(preprocessedValues, DiffValues{
+			value:        value,
+			clusterValue: clusterValue,
+			listedPath:   listedPath,
+			pathToKey:    pathToKey,
+			diffFn:       diffFn,
+		})
+	}
+
+	// Pass 2: Actually do the diff and substitute in any matching results
+	for _, v := range preprocessedValues {
+		patchedString, updatedCapturegroups := v.diffFn.Diff(v.value, v.clusterValue, sharedCapturegroups)
+		sharedCapturegroups = updatedCapturegroups
+		err := SetNestedString(obj.injectedObjFromTemplate.Object, patchedString, v.listedPath...)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to update value of inline diff func result for field %s, %w", pathToKey, err))
+			errs = append(errs, fmt.Errorf("failed to update value of inline diff func result for field %s, %w", v.pathToKey, err))
 			continue
 		}
 	}

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -821,6 +821,7 @@ func (e InlineDiffError) Error() string {
 
 func (obj InfoObject) runInlineDiffFuncs() error {
 	var errs []error
+	sharedCapturegroups := CapturedValues{}
 	for pathToKey, inlineDiffFunc := range obj.templateFieldConf {
 		listedPath, err := pathToList(pathToKey)
 		if err != nil {
@@ -850,7 +851,9 @@ func (obj InfoObject) runInlineDiffFuncs() error {
 			errs = append(errs, fmt.Errorf("failed to validate the inline diff for field %s, %w", pathToKey, err))
 			continue
 		}
-		err = SetNestedString(obj.injectedObjFromTemplate.Object, diffFn.Diff(value, clusterValue), listedPath...)
+		patchedString, updatedCapturegroups := diffFn.Diff(value, clusterValue, sharedCapturegroups)
+		sharedCapturegroups = updatedCapturegroups
+		err = SetNestedString(obj.injectedObjFromTemplate.Object, patchedString, listedPath...)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to update value of inline diff func result for field %s, %w", pathToKey, err))
 			continue

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -564,6 +564,22 @@ func TestCompareRun(t *testing.T) {
 			withSubTestSuffix("With Mismatched Capturegroups").
 			withMetadataFile("metadata-with-mismatched-capturegroups.yaml").
 			withChecks(defaultChecks.withPrefixedSuffix("WithMismatchedCapturegroups")),
+		defaultTest("ReferenceV2InlineCapturegroups").
+			withSubTestSuffix("With Consistency Across Capturegroups").
+			withMetadataFile("metadata-with-diff-across-capture-groups.yaml").
+			withChecks(defaultChecks.withPrefixedSuffix("WithDiffAcrossCapturegroups")),
+		defaultTest("ReferenceV2InlineCapturegroups").
+			withSubTestSuffix("With Diff Across Capturegroups").
+			withMetadataFile("metadata-with-diff-across-capture-groups-mismatch.yaml").
+			withChecks(defaultChecks.withPrefixedSuffix("WithDiffAcrossCapturegroupsMismatch")),
+		defaultTest("ReferenceV2InlineCapturegroups").
+			withSubTestSuffix("With Consistency Across Capturegroups and Regex").
+			withMetadataFile("metadata-with-diff-across-capture-groups-and-regex.yaml").
+			withChecks(defaultChecks.withPrefixedSuffix("WithDiffAcrossCapturegroupsAndRegex")),
+		defaultTest("ReferenceV2InlineCapturegroups").
+			withSubTestSuffix("With Diff Across Capturegroups and Regex").
+			withMetadataFile("metadata-with-diff-across-capture-groups-and-regex-mismatch.yaml").
+			withChecks(defaultChecks.withPrefixedSuffix("WithDiffAcrossCapturegroupsAndRegexMismatch")),
 		defaultTest("ReferenceV2PerFieldMatcherValidation").
 			withSubTestSuffix("Matcher Does Not exist").
 			withMetadataFile("metadata-does-not-exist.yaml").

--- a/pkg/compare/referenceV2.go
+++ b/pkg/compare/referenceV2.go
@@ -289,7 +289,7 @@ var InlineDiffs = map[inlineDiffType]InlineDiff{
 }
 
 type InlineDiff interface {
-	Diff(templateValue, crValue string) string
+	Diff(templateValue, crValue string, sharedCapturedValues CapturedValues) (string, CapturedValues)
 	Validate(templateValue string) error
 }
 

--- a/pkg/compare/regexInlineDiff.go
+++ b/pkg/compare/regexInlineDiff.go
@@ -54,14 +54,16 @@ func (c *capturedValueIndices) getTopLevelIndices() []capturedGroupIndex {
 	return c.topLevelCaputuredGroups
 }
 
-func (id RegexInlineDiff) Diff(regex, crValue string) string {
+func (id RegexInlineDiff) Diff(regex, crValue string, sharedCapturedValues CapturedValues) (string, CapturedValues) {
 	re, _ := regexp.Compile(regex)
 	matchedIndices := re.FindStringSubmatchIndex(crValue)
 	if matchedIndices == nil {
-		return regex
+		return regex, sharedCapturedValues
 	}
 
-	capturedValues := capturedValueIndices{}
+	capturedValues := capturedValueIndices{
+		CapturedValues: sharedCapturedValues,
+	}
 	for n, name := range re.SubexpNames() {
 		if name == "" {
 			continue
@@ -77,7 +79,7 @@ func (id RegexInlineDiff) Diff(regex, crValue string) string {
 		result = result[:tl.start] + capturedValues.groupValues(tl.name) + result[tl.end:]
 	}
 	result += capturedValues.getWarnings()
-	return result
+	return result, capturedValues.CapturedValues
 }
 
 func (id RegexInlineDiff) Validate(regex string) error {

--- a/pkg/compare/regexInlineDiff_test.go
+++ b/pkg/compare/regexInlineDiff_test.go
@@ -47,7 +47,7 @@ func TestInlineRegexDiff(t *testing.T) {
 			expected: "Hello",
 			expectedCg: CapturedValues{
 				caps: map[string][]string{
-					"simple": []string{"llo"},
+					"simple": {"llo"},
 				},
 			},
 		},
@@ -62,7 +62,7 @@ func TestInlineRegexDiff(t *testing.T) {
 			expected: "Hello, World",
 			expectedCg: CapturedValues{
 				caps: map[string][]string{
-					"simple": []string{"llo"},
+					"simple": {"llo"},
 				},
 			},
 		},
@@ -73,12 +73,12 @@ func TestInlineRegexDiff(t *testing.T) {
 				"WARNING: Capturegroup (?<simple>…) matched multiple values: « othermatch | llo »",
 			initialCg: CapturedValues{
 				caps: map[string][]string{
-					"simple": []string{"othermatch"},
+					"simple": {"othermatch"},
 				},
 			},
 			expectedCg: CapturedValues{
 				caps: map[string][]string{
-					"simple": []string{"othermatch", "llo"},
+					"simple": {"othermatch", "llo"},
 				},
 			},
 		},
@@ -89,7 +89,7 @@ func TestInlineRegexDiff(t *testing.T) {
 				"WARNING: Capturegroup (?<simple>…) matched multiple values: « Hello | World »",
 			expectedCg: CapturedValues{
 				caps: map[string][]string{
-					"simple": []string{"Hello", "World"},
+					"simple": {"Hello", "World"},
 				},
 			},
 		},
@@ -120,9 +120,9 @@ func TestInlineRegexDiff(t *testing.T) {
 				"WARNING: Capturegroup (?<nested>…) matched multiple values: « ello | orld »",
 			expectedCg: CapturedValues{
 				caps: map[string][]string{
-					"hello":  []string{"Hello"},
-					"world":  []string{"World"},
-					"nested": []string{"ello", "orld"},
+					"hello":  {"Hello"},
+					"world":  {"World"},
+					"nested": {"ello", "orld"},
 				},
 			},
 		},

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsAndRegexMismatcherr.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsAndRegexMismatcherr.golden
@@ -1,0 +1,2 @@
+
+error code:1

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsAndRegexMismatchout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsAndRegexMismatchout.golden
@@ -1,0 +1,24 @@
+**********************************
+
+Cluster CR: v1_ConfigMap_kubernetes-dashboard_configmap-with-multiple-values-mismatch
+Reference File: cm-with-diff-across-capturegroups-mismatch.yaml
+Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch
+--- TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch	DATE
++++ TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch	DATE
+@@ -10,6 +10,5 @@
+   list:
+   - bigTextBlock: |-
+       This is a big text block with some static content, like this line.
+-      It also has a place where (?<username>=mismatchuser) would put in their own name. (?<username>=mismatchuser) would put in their own name.
++      It also has a place where exampleuser would put in their own name. exampleuser would put in their own name.
+       More complicated [capture groups] are also allowed.
+-      WARNING: Capturegroup (?<username>…) matched multiple values: « mismatchuser | exampleuser »
+
+**********************************
+
+Summary
+CRs with diffs: 1/1
+No validation issues with the cluster
+No CRs are unmatched to reference CRs
+Metadata Hash: $METADATA_HASH$
+No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsAndRegexMismatchout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsAndRegexMismatchout.golden
@@ -5,7 +5,14 @@ Reference File: cm-with-diff-across-capturegroups-mismatch.yaml
 Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch
 --- TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch	DATE
 +++ TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch	DATE
-@@ -10,6 +10,5 @@
+@@ -6,12 +6,9 @@
+   name: configmap-with-multiple-values-mismatch
+   namespace: kubernetes-dashboard
+ spec:
+-  first: |-
+-    This short group establishes (?<username>=mismatchuser)
+-    WARNING: Capturegroup (?<username>…) matched multiple values: « mismatchuser | exampleuser »
++  first: This short group establishes mismatchuser
    list:
    - bigTextBlock: |-
        This is a big text block with some static content, like this line.

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsAndRegexout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsAndRegexout.golden
@@ -1,0 +1,6 @@
+Summary
+CRs with diffs: 0/1
+No validation issues with the cluster
+No CRs are unmatched to reference CRs
+Metadata Hash: $METADATA_HASH$
+No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsMismatcherr.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsMismatcherr.golden
@@ -1,0 +1,2 @@
+
+error code:1

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsMismatchout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsMismatchout.golden
@@ -1,0 +1,24 @@
+**********************************
+
+Cluster CR: v1_ConfigMap_kubernetes-dashboard_configmap-with-multiple-values-mismatch
+Reference File: cm-with-diff-across-capturegroups-mismatch.yaml
+Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch
+--- TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch	DATE
++++ TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch	DATE
+@@ -10,6 +10,5 @@
+   list:
+   - bigTextBlock: |-
+       This is a big text block with some static content, like this line.
+-      It also has a place where (?<username>=mismatchuser) would put in their own name. (?<username>=mismatchuser) would put in their own name.
++      It also has a place where exampleuser would put in their own name. exampleuser would put in their own name.
+       More complicated [capture groups] are also allowed.
+-      WARNING: Capturegroup (?<username>…) matched multiple values: « mismatchuser | exampleuser »
+
+**********************************
+
+Summary
+CRs with diffs: 1/1
+No validation issues with the cluster
+No CRs are unmatched to reference CRs
+Metadata Hash: $METADATA_HASH$
+No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsMismatchout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsMismatchout.golden
@@ -5,7 +5,14 @@ Reference File: cm-with-diff-across-capturegroups-mismatch.yaml
 Diff Output: diff -u -N TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch
 --- TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch	DATE
 +++ TEMP/v1_configmap_kubernetes-dashboard_configmap-with-multiple-values-mismatch	DATE
-@@ -10,6 +10,5 @@
+@@ -6,12 +6,9 @@
+   name: configmap-with-multiple-values-mismatch
+   namespace: kubernetes-dashboard
+ spec:
+-  first: |-
+-    This short group establishes (?<username>=mismatchuser)
+-    WARNING: Capturegroup (?<username>…) matched multiple values: « mismatchuser | exampleuser »
++  first: This short group establishes mismatchuser
    list:
    - bigTextBlock: |-
        This is a big text block with some static content, like this line.

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localWithDiffAcrossCapturegroupsout.golden
@@ -1,0 +1,6 @@
+Summary
+CRs with diffs: 0/1
+No validation issues with the cluster
+No CRs are unmatched to reference CRs
+Metadata Hash: $METADATA_HASH$
+No patched CRs

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/cm-with-diff-across-capturegroups-mismatch.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/cm-with-diff-across-capturegroups-mismatch.yaml
@@ -1,0 +1,16 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: configmap-with-multiple-values-mismatch
+  namespace: kubernetes-dashboard
+spec:
+  first: "This short group establishes (?<username>[a-z0-9]+)"
+  list:
+    {{- range .spec.list }}
+    - bigTextBlock: |-
+        This is a big text block with some static content, like this line.
+        It also has a place where (?<username>[a-z0-9]+) would put in their own name. (?<username>[a-z0-9]+) would put in their own name.
+        More complicated [(?<group>[^\]]+)] are also allowed.
+    {{- end }}

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/cm-with-diff-across-capturegroups.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/cm-with-diff-across-capturegroups.yaml
@@ -1,0 +1,16 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: configmap-with-multiple-values
+  namespace: kubernetes-dashboard
+spec:
+  first: "This short group establishes (?<username>[a-z0-9]+)"
+  list:
+    {{- range .spec.list }}
+    - bigTextBlock: |-
+        This is a big text block with some static content, like this line.
+        It also has a place where (?<username>[a-z0-9]+) would put in their own name. (?<username>[a-z0-9]+) would put in their own name.
+        More complicated [(?<group>[^\]]+)] are also allowed.
+    {{- end }}

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/metadata-with-diff-across-capture-groups-and-regex-mismatch.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/metadata-with-diff-across-capture-groups-and-regex-mismatch.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        allOf:
+          - path: cm-with-diff-across-capturegroups-mismatch.yaml
+            config:
+                perField:
+                - pathTokey: spec.first
+                  inlineDiffFunc: regex
+                - pathToKey: spec.list.0.bigTextBlock
+                  inlineDiffFunc: capturegroups

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/metadata-with-diff-across-capture-groups-and-regex.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/metadata-with-diff-across-capture-groups-and-regex.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        allOf:
+          - path: cm-with-diff-across-capturegroups.yaml
+            config:
+                perField:
+                - pathToKey: spec.first
+                  inlineDiffFunc: regex
+                - pathToKey: spec.list.0.bigTextBlock
+                  inlineDiffFunc: capturegroups

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/metadata-with-diff-across-capture-groups-mismatch.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/metadata-with-diff-across-capture-groups-mismatch.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        allOf:
+          - path: cm-with-diff-across-capturegroups-mismatch.yaml
+            config:
+                perField:
+                - pathTokey: spec.first
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.list.0.bigTextBlock
+                  inlineDiffFunc: capturegroups

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/metadata-with-diff-across-capture-groups.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/metadata-with-diff-across-capture-groups.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        allOf:
+          - path: cm-with-diff-across-capturegroups.yaml
+            config:
+                perField:
+                - pathToKey: spec.first
+                  inlineDiffFunc: capturegroups
+                - pathToKey: spec.list.0.bigTextBlock
+                  inlineDiffFunc: capturegroups

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/resources/multi-mismatch.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/resources/multi-mismatch.yaml
@@ -1,0 +1,14 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: configmap-with-multiple-values-mismatch
+  namespace: kubernetes-dashboard
+spec:
+  first: "This short group establishes mismatchuser"
+  list:
+    - bigTextBlock: |-
+        This is a big text block with some static content, like this line.
+        It also has a place where exampleuser would put in their own name. exampleuser would put in their own name.
+        More complicated [capture groups] are also allowed.

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/resources/multi.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/resources/multi.yaml
@@ -1,0 +1,14 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: configmap-with-multiple-values
+  namespace: kubernetes-dashboard
+spec:
+  first: "This short group establishes exampleuser"
+  list:
+    - bigTextBlock: |-
+        This is a big text block with some static content, like this line.
+        It also has a place where exampleuser would put in their own name. exampleuser would put in their own name.
+        More complicated [capture groups] are also allowed.


### PR DESCRIPTION
- **Omit actual metadata hash from most end-to-end tests to simplify test output comparison**
- **Enforce capture group contents across multiple fields within an object**
- **Run InlineDiff in a 2-phase loop; once to capture all capturegroups, and once to use them**
