### PR TITLE
helm-convert: Enable capturegroup default substitution

### DIFF
--- a/addon-tools/helm-convert/README.md
+++ b/addon-tools/helm-convert/README.md
@@ -100,6 +100,46 @@ service:
       k8s-app: {}
 ```
 
+### Capturegroup default substitution
+
+The helm-convert tool supports a mechanism to substitute capturegroup default
+values if required.  If the defaults.yaml contains a section called
+`captureGroup_defaults`, and the YAML in question contains one or more
+captureGroups using either the `regex` or `capturegroup` inlineDiff mechanism,
+all capturegroups with a default in the `captureGroup_defaults` section will be
+replaced by the default value when converting the reference template to helm
+chart template.
+
+For example, if you have a CR like this:
+
+```yaml
+apiVersion: v1
+Kind: Foo
+spec:
+  value: |-
+    Something with (?<blee>.*) in it,
+    And another capturegroup (?<bar>.*) with no default.
+```
+
+With this in the values.yaml:
+
+```yaml
+Foo:
+- captureGroup_defaults:
+    blee: 42
+```
+
+The resulting Helm template will look like this:
+
+```yaml
+apiVersion: v1
+Kind: Foo
+spec:
+  value: |-
+    Something with 42 in it,
+    And another capturegroup (?<bar>.*) with no default.
+```
+
 ## Auto Extracting of default values from Existing CRs
 
 another feature that can help in initial building of values.yaml files is extracting default values from existing CRs,

--- a/addon-tools/helm-convert/convert/convert.go
+++ b/addon-tools/helm-convert/convert/convert.go
@@ -23,7 +23,7 @@ const helmTemplatesDir = "templates"
 func NewCmd() *cobra.Command {
 	options := Options{}
 	cmd := &cobra.Command{
-		Use:   "helm-convert -r <REFERENCE_PATH> -n <CHART_DIRECTORY> [-d <EXISTING_CRS_DIR>] [-v <PREVIOUS_VALUES_PATH>] [--description <DESCRIPTION>] [--version <VERSION>]",
+		Use:   "helm-convert -r <REFERENCE_PATH> -n <CHART_DIRECTORY> [-d <EXISTING_CRS_DIR>] [-v <PREVIOUS_VALUES_PATH>] [--description <DESCRIPTION>] [--helm-version <VERSION>]",
 		Short: "Convert kube-compare reference configs into a Helm chart.",
 		Long: `The 'helm-convert' command generates a Helm chart from kube-compare reference configurations and creates a values.yaml file based on the values used in the templates included in the reference. 
 You need to provide the path to the reference YAML file using the -r flag and the directory where the Helm chart should be created using the -n flag. 
@@ -43,7 +43,7 @@ The tool helps automate the creation of values.yaml and supports default values 
 	cmd.Flags().StringVarP(&options.defaultPath, "defaults", "d", "", "Path to directory with the CRs that the tool will extract default values from")
 	cmd.Flags().StringVarP(&options.valuesPath, "values", "v", "", "Path to existing values.yaml file")
 	cmd.Flags().StringVar(&options.chartDescription, "description", "This Helm Chart was generated from a kube-compare reference", "Description for generated Helm Chart")
-	cmd.Flags().StringVar(&options.chartVersion, "version", "1", "Version of generated Helm Chart")
+	cmd.Flags().StringVar(&options.chartVersion, "helm-version", "1", "Version of generated Helm Chart")
 	return cmd
 }
 

--- a/addon-tools/helm-convert/convert/convert.go
+++ b/addon-tools/helm-convert/convert/convert.go
@@ -59,6 +59,7 @@ type Options struct {
 func convertToHelm(o *Options) error {
 	helmTemplates := make(map[string]string)
 	helmValues := make(map[string]any)
+	var preValues map[string]any
 	crsWithDefaults := make(map[string]map[string]interface{})
 
 	cfs, err := compare.GetRefFS(o.refPath)
@@ -79,12 +80,19 @@ func convertToHelm(o *Options) error {
 		}
 	}
 
+	if o.valuesPath != "" {
+		preValues, err = loadValues(o.valuesPath)
+		if err != nil {
+			return err
+		}
+	}
+
 	for _, t := range templates {
 
 		visitor := ExpectedValuesFinder{}
 		Inspect(t.GetTemplateTree().Root, visitor.Visit())
 
-		helmTemplate, err := convertToHelmTemplate(cfs, t)
+		helmTemplate, err := convertToHelmTemplate(cfs, t, preValues)
 		if err != nil {
 			return err
 		}
@@ -107,11 +115,7 @@ func convertToHelm(o *Options) error {
 		}
 	}
 
-	if o.valuesPath != "" {
-		preValues, err := loadValues(o.valuesPath)
-		if err != nil {
-			return err
-		}
+	if preValues != nil {
 		merged, err := compare.MergeManifests(&unstructured.Unstructured{Object: preValues}, &unstructured.Unstructured{Object: helmValues})
 		if err != nil {
 			return fmt.Errorf("failed to merge given values with generated values %w", err)
@@ -177,7 +181,26 @@ func loadYAMLFiles(root string) (map[string]map[string]interface{}, error) {
 	return filesMapping, nil
 }
 
-func convertToHelmTemplate(cfs fs.FS, t compare.ReferenceTemplate) (string, error) {
+func cgDefaultsFor(compName string, helmValues map[string]any) (map[string]any, error) {
+	if values, ok := helmValues[compName].([]any); ok && len(values) > 0 {
+		if section, ok := values[0].(map[string]any); ok && len(section) > 0 {
+			if dflts, ok := section["captureGroup_defaults"].(map[string]any); ok && len(dflts) > 0 {
+				return dflts, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("no captureGroup_defaults found for %s", compName)
+}
+
+func removeCgDefaults(compName string, helmValues map[string]any) {
+	if values, ok := helmValues[compName].([]any); ok && len(values) > 0 {
+		if section, ok := values[0].(map[string]any); ok && len(section) > 0 {
+			delete(section, "captureGroup_defaults")
+		}
+	}
+}
+
+func convertToHelmTemplate(cfs fs.FS, t compare.ReferenceTemplate, helmValues map[string]any) (string, error) {
 	var templateStructure = `{{- $values := list (dict)}}
 {{- if .Values.%v}}
 {{- $values = .Values.%v }}
@@ -187,12 +210,43 @@ func convertToHelmTemplate(cfs fs.FS, t compare.ReferenceTemplate) (string, erro
 %v 
 {{ end -}}
 `
-	content, err := fs.ReadFile(cfs, t.GetIdentifier())
+	data, err := fs.ReadFile(cfs, t.GetIdentifier())
 	if err != nil {
 		return "", fmt.Errorf("failed to read template named: %s %w", t.GetIdentifier(), err)
 	}
+
 	compName := getCompName(t.GetIdentifier())
-	helmTemplate := fmt.Sprintf(templateStructure, compName, compName, string(content))
+
+	content := string(data)
+
+	if len(t.GetConfig().GetInlineDiffFuncs()) > 0 {
+		if dflts, err := cgDefaultsFor(compName, helmValues); err == nil {
+			cgs := compare.CapturegroupIndex(content)
+			contentBuilder := strings.Builder{}
+			idx := 0
+			for _, group := range cgs {
+				if idx < group.Start {
+					contentBuilder.WriteString(content[idx:group.Start])
+				}
+				if dflt, ok := dflts[group.Name]; ok {
+					fmt.Fprintf(os.Stderr, "  %s replacing CaptureGroup (?<%s>...) at [%d:%d] with default: %v\n", compName, group.Name, group.Start, group.End, dflt)
+					contentBuilder.WriteString(fmt.Sprintf("%v", dflt))
+				} else {
+					contentBuilder.WriteString(content[group.Start:group.End])
+				}
+				idx = group.End
+			}
+			if idx < len(content) {
+				contentBuilder.WriteString(content[idx:])
+			}
+			content = contentBuilder.String()
+			// Now that we've fully consumed the defaults, strip them so they don't appear in the Helm chart...
+			removeCgDefaults(compName, helmValues)
+		}
+	}
+
+	helmTemplate := fmt.Sprintf(templateStructure, compName, compName, content)
+
 	return helmTemplate, nil
 }
 

--- a/addon-tools/helm-convert/convert/convert_test.go
+++ b/addon-tools/helm-convert/convert/convert_test.go
@@ -81,6 +81,10 @@ func TestConvert(t *testing.T) {
 			name:           "Values Contain Keys With Dots",
 			passDefaultDir: true,
 		},
+		{
+			name:           "Capturegroup Defaults",
+			passValuesFile: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/addon-tools/helm-convert/convert/convert_test.go
+++ b/addon-tools/helm-convert/convert/convert_test.go
@@ -28,7 +28,7 @@ type Test struct {
 	name           string
 	passDefaultDir bool
 	passValuesFile bool
-	version        string
+	helmVersion    string
 	description    string
 }
 
@@ -61,12 +61,12 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:        "Templates Are Created As Expected",
-			version:     "2",
+			helmVersion: "2",
 			description: "Templates Are Created As Expected Test",
 		},
 		{
 			name:        "Odd Filenames",
-			version:     "2",
+			helmVersion: "2",
 			description: "Test escaping of odd or unexpected characters in reference filenames",
 		},
 		{
@@ -98,8 +98,8 @@ func TestConvert(t *testing.T) {
 			if test.passValuesFile {
 				require.NoError(t, cmd.Flags().Set("values", test.getValuesPath()))
 			}
-			if test.version != "" {
-				require.NoError(t, cmd.Flags().Set("version", test.version))
+			if test.helmVersion != "" {
+				require.NoError(t, cmd.Flags().Set("helm-version", test.helmVersion))
 			}
 			if test.description != "" {
 				require.NoError(t, cmd.Flags().Set("description", test.description))

--- a/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/reference/metadata.yaml
+++ b/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/reference/metadata.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: DemonSets
+        allOf:
+          - path: sa.yaml
+            config:
+              perField:
+              - pathToKey: spec.value
+                inlineDiffFunc: capturegroups
+          - path: secret.yaml

--- a/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/reference/sa.yaml
+++ b/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/reference/sa.yaml
@@ -1,0 +1,11 @@
+apiVersion: {{ .apiVersion }}
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: {{ .metadata.name }}
+  namespace: kubernetes-dashboard
+spec:
+  value: |-
+    Long string with (?<one>[a-z0-9]*) capturegroup
+    And another (?<two>[a-z0-9]*) capturegorup

--- a/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/reference/secret.yaml
+++ b/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/reference/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: {{ .metadata.name }}
+  namespace: kubernetes-dashboard
+type: Opaque
+{{ if .data }}data:
+  {{ .data | toYaml }}{{ end }}

--- a/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/result/Chart.yaml
+++ b/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/result/Chart.yaml
@@ -1,0 +1,3 @@
+description: This Helm Chart was generated from a kube-compare reference
+name: Capturegroup Defaults
+version: "1"

--- a/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/result/templates/sa.yaml
+++ b/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/result/templates/sa.yaml
@@ -1,0 +1,19 @@
+{{- $values := list (dict)}}
+{{- if .Values.sa}}
+{{- $values = .Values.sa }}
+{{- end }}
+{{- range $values -}}
+---
+apiVersion: {{ .apiVersion }}
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: {{ .metadata.name }}
+  namespace: kubernetes-dashboard
+spec:
+  value: |-
+    Long string with 100 capturegroup
+    And another (?<two>[a-z0-9]*) capturegorup
+ 
+{{ end -}}

--- a/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/result/templates/secret.yaml
+++ b/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/result/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{- $values := list (dict)}}
+{{- if .Values.secret}}
+{{- $values = .Values.secret }}
+{{- end }}
+{{- range $values -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: {{ .metadata.name }}
+  namespace: kubernetes-dashboard
+type: Opaque
+{{ if .data }}data:
+  {{ .data | toYaml }}{{ end }}
+ 
+{{ end -}}

--- a/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/result/values.yaml
+++ b/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/result/values.yaml
@@ -1,0 +1,8 @@
+sa:
+- apiVersion: v1
+  metadata:
+    name: kubernetes-dashboard
+secret:
+- data: {}
+  metadata:
+    name: {}

--- a/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/values.yaml
+++ b/addon-tools/helm-convert/convert/testdata/CapturegroupDefaults/values.yaml
@@ -1,0 +1,6 @@
+sa:
+- apiVersion: v1
+  metadata:
+    name: kubernetes-dashboard
+  captureGroup_defaults:
+    one: 100


### PR DESCRIPTION
- **helm-convert: Change --version to --helm-version to stop collisions with the native --version flag**
- **helm-convert: Enable capturegroup default substitution**

As detailed in the doc changes, this allows us to substitute defaults into
capturegroups when creating the associated helm chart, for cases when we don't
want the capturegroups to be visible in the resulting CRs.

Prerequisite for https://issues.redhat.com/browse/OCPBUGS-47784
