### PR TITLE
Final cleanup for removal of the go workspace configuration

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -54,5 +54,5 @@ commits focussed (`git add -p` will help with this).
 
 We use go module vendoring to ensure all required modules are available for
 build.  If a change you are adding requires adding a new go module, add the go
-module and the result of running `go work vendor` to add the new module and its
+module and the result of running `go mod vendor` to add the new module and its
 code in an initial commit, with the related code changes in a following commit.

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -9,4 +9,4 @@ fi
 export GOCACHE=/tmp/
 export GOLANGCI_LINT_CACHE=/tmp/.cache
 "${golangci_lint}" version
-"${golangci_lint}" run --verbose --print-resources-usage $(go work edit --json | grep DiskPath | awk '{print $2"/..."}' | tr -d '"' | tr '\n' ' ')
+"${golangci_lint}" run --verbose --print-resources-usage ./...


### PR DESCRIPTION
- **Fix golint script to work without 'go work'**
- **Update contributing guide to match removal of the go workspace**
