### PR TITLE
[release-4.18] OCPBUGS-50810: Hide all reference correlation overlaps behind a single warning

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -216,15 +216,23 @@ In such scenarios take these steps:
 
 #### There can be more than one Reference Design CR of the same Kind
 
-In this case you will have a warning presented before the diff output, formatted similar to this:
-`More then one template with same apiVersion, metadata_namespace, kind. By Default for each Cluster CR that is correlated
-to one of these templates the template with the least number of diffs will be used. To use a different template for a
-specific CR specify it in the diff-config (-c flag) Template names are:`
+In this case you will have a warning presented before the diff output,
+formatted similar to this: `The reference contains overlapping object
+definitions which may result in unexpected correlation results. Re-run with
+'--verbose' output enabled to view a detailed description of the issues`
 
-This means the template contains two CRs with the same apiversion-kind-name-namespace but different spec. In such cases
-For each cluster CR the template that contains the least diffs will be used, to choose a different template for the CR
-pass a user config (-c) and specify in the user config file the template that should be matched to the CR. For info about
-the exact syntax view the user config section.
+This means the template contains two CRs with the same
+apiversion-kind-name-namespace but different spec. In such cases for each
+cluster CR the template that contains the least diffs will be used, to choose a
+different template for the CR pass a user config (-c) and specify in the user
+config file the template that should be matched to the CR. For info about the
+exact syntax view the user config section.  As the warning text suggests,
+running again with `--verbose` will list all the name collisions and which
+templates are contributing to the issue.
+
+This may also be intentional, in the case of 'OneOf' metadata directives, but
+it is best practice to either have hard-coded names, or leave the names
+templated so any CRs can match, if possible.
 
 ## Patching the reference
 

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -358,7 +358,7 @@ func (o *Options) setupCorrelators() error {
 		correlators = append(correlators, manualCorrelator)
 	}
 
-	groupCorrelator, err := NewGroupCorrelator(defaultFieldGroups, o.templates)
+	groupCorrelator, err := NewGroupCorrelator(defaultFieldGroups, o.templates, o.verboseOutput)
 	if err != nil {
 		return err
 	}
@@ -387,7 +387,7 @@ func (o *Options) setupOverrideCorrelators() error {
 		correlators = append(correlators, manualOverrideCorrelator)
 	}
 
-	groupCorrelator, err := NewGroupCorrelator(defaultFieldGroups, o.userOverrides)
+	groupCorrelator, err := NewGroupCorrelator(defaultFieldGroups, o.userOverrides, o.verboseOutput)
 	if err != nil {
 		return err
 	}

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -360,7 +360,13 @@ func TestCompareRun(t *testing.T) {
 		defaultTest("Template Has No Kind").
 			withModes([]Mode{{Live, LocalRef}}),
 		defaultTest("Two Templates With Same apiVersion Kind Name Namespace"),
+		defaultTest("Two Templates With Same apiVersion Kind Name Namespace").
+			withVerboseOutput().
+			withChecks(defaultChecks.withPrefixedSuffix("Verbose")),
 		defaultTest("Two Templates With Same Kind Namespace"),
+		defaultTest("Two Templates With Same Kind Namespace").
+			withVerboseOutput().
+			withChecks(defaultChecks.withPrefixedSuffix("Verbose")),
 		defaultTest("User Config Doesnt Exist").
 			withUserConfig(userConfigFileName).
 			withChecks(Checks{Out: defaultCheckOut,

--- a/pkg/compare/correlator.go
+++ b/pkg/compare/correlator.go
@@ -115,7 +115,7 @@ type GroupCorrelator[T CorrelationEntry] struct {
 // For fieldsGroups =  {{{"metadata", "namespace"}, {"kind"}}, {{"kind"}}} and the following templates: [fixedKindTemplate, fixedNamespaceKindTemplate]
 // the fixedNamespaceKindTemplate will be added to a mapping where the keys are  in the format of `namespace_kind`. The fixedKindTemplate
 // will be added to a mapping where the keys are  in the format of `kind`.
-func NewGroupCorrelator[T CorrelationEntry](fieldGroups [][][]string, objects []T) (*GroupCorrelator[T], error) {
+func NewGroupCorrelator[T CorrelationEntry](fieldGroups [][][]string, objects []T, verboseOutput bool) (*GroupCorrelator[T], error) {
 	sort.Slice(fieldGroups, func(i, j int) bool {
 		return len(fieldGroups[i]) >= len(fieldGroups[j])
 	})
@@ -134,7 +134,11 @@ func NewGroupCorrelator[T CorrelationEntry](fieldGroups [][][]string, objects []
 
 		err := fc.ValidateTemplates()
 		if err != nil {
-			klog.Warning(err)
+			if verboseOutput {
+				klog.Warning(err)
+			} else {
+				klog.Warning("The reference contains overlapping object definitions which may result in unexpected correlation results. Re-run with '--verbose' output enabled to view a detailed description of the issues")
+			}
 		}
 
 		if len(objects) == 0 {
@@ -285,7 +289,7 @@ func (f *FieldCorrelator[T]) ValidateTemplates() error {
 	for _, values := range f.objects {
 		if len(values) > 1 {
 			errs = append(errs, fmt.Errorf(
-				"More then one template with same %s. By Default for each Cluster CR that is correlated "+
+				"More than one template with same %s. By Default for each Cluster CR that is correlated "+
 					"to one of these templates the template with the least number of diffs will be used. "+
 					"To use a different template for a specific CR specify it in the diff-config (-c flag) "+
 					"Template names are: %s",

--- a/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localVerboseerr.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localVerboseerr.golden
@@ -1,0 +1,2 @@
+
+error code:1

--- a/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localVerboseout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localVerboseout.golden
@@ -1,4 +1,4 @@
-The reference contains overlapping object definitions which may result in unexpected correlation results. Re-run with '--verbose' output enabled to view a detailed description of the issues
+More than one template with same apiVersion, metadata_namespace, kind. By Default for each Cluster CR that is correlated to one of these templates the template with the least number of diffs will be used. To use a different template for a specific CR specify it in the diff-config (-c flag) Template names are: apps.v1.DaemonSet.kube-system.kindnet.yaml, apps.v1.DaemonSet.kube-system.kindnet2.yaml
 **********************************
 
 Cluster CR: apps/v1_DaemonSet_SomeNS_Name

--- a/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localVerboseout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localVerboseout.golden
@@ -1,0 +1,15 @@
+More than one template with same apiVersion, metadata_name, metadata_namespace, kind. By Default for each Cluster CR that is correlated to one of these templates the template with the least number of diffs will be used. To use a different template for a specific CR specify it in the diff-config (-c flag) Template names are: apps.v1.DaemonSet.kube-system.kindnet.yaml, apps.v1.DaemonSet.kube-system.kindnet.yaml
+**********************************
+
+Cluster CR: apps/v1_DaemonSet_SomeNS_Name
+Reference File: apps.v1.DaemonSet.kube-system.kindnet.yaml
+Diff Output: None
+
+**********************************
+
+Summary
+CRs with diffs: 0/1
+No validation issues with the cluster
+No CRs are unmatched to reference CRs
+Metadata Hash: 2a036377d67f5dc215bf351f995a791aa4c3b6900f1fd1e44b914008c476b91b
+No patched CRs

--- a/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localout.golden
@@ -1,4 +1,4 @@
-More then one template with same apiVersion, metadata_name, metadata_namespace, kind. By Default for each Cluster CR that is correlated to one of these templates the template with the least number of diffs will be used. To use a different template for a specific CR specify it in the diff-config (-c flag) Template names are: apps.v1.DaemonSet.kube-system.kindnet.yaml, apps.v1.DaemonSet.kube-system.kindnet.yaml
+The reference contains overlapping object definitions which may result in unexpected correlation results. Re-run with '--verbose' output enabled to view a detailed description of the issues
 Summary
 CRs with diffs: 0/1
 No validation issues with the cluster

--- a/pkg/compare/testdata/WhenUsingDiffAllFlag-AllUnmatchedResourcesAppearInSummary/localout.golden
+++ b/pkg/compare/testdata/WhenUsingDiffAllFlag-AllUnmatchedResourcesAppearInSummary/localout.golden
@@ -1,4 +1,4 @@
-More then one template with same apiVersion, metadata_namespace, kind. By Default for each Cluster CR that is correlated to one of these templates the template with the least number of diffs will be used. To use a different template for a specific CR specify it in the diff-config (-c flag) Template names are: apps.v1.DaemonSet.kube-system.kindnet.yaml, apps.v1.DaemonSet.kube-system.kindnet2.yaml
+The reference contains overlapping object definitions which may result in unexpected correlation results. Re-run with '--verbose' output enabled to view a detailed description of the issues
 **********************************
 
 Cluster CR: apps/v1_DaemonSet_SomeNS_Name


### PR DESCRIPTION
The specific issues are revealed when `--verbose` output is enabled.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
