### PR TITLE
OCPBUGS-51191: Sanitize capturegrouos against partial matches

### DIFF
--- a/pkg/compare/capturegroupsInlineDiff.go
+++ b/pkg/compare/capturegroupsInlineDiff.go
@@ -55,6 +55,7 @@ type CapturegroupsInlineDiff struct{}
 type diffInfo struct {
 	dmp   *diffmatchpatch.DiffMatchPatch
 	diffs []diffmatchpatch.Diff
+	cg    []CgInfo
 	CapturedValues
 }
 
@@ -66,10 +67,6 @@ type CgInfo struct {
 }
 
 // Options for development purposes to test alternative implementations
-
-// If true, use a line-granular diff.
-// Otherwise, do a word-granular diff.
-var diffByLines = false
 
 // If true, add string-end anchors to the entire pattern when quoted.
 // Otherwise only do so when a capture group begins or ends the string.
@@ -187,6 +184,13 @@ func CapturegroupQuoteMeta(pattern string, groups []CgInfo) string {
 	return strings.Join(results, "")
 }
 
+func NewDiffInfo(pattern string, sharedCapturedValues CapturedValues) *diffInfo {
+	o := diffInfo{CapturedValues: sharedCapturedValues}
+	o.dmp = diffmatchpatch.New()
+	o.cg = CapturegroupIndex(pattern)
+	return &o
+}
+
 // Using the 'deletion' side as the pattern, record all matching capturegroups
 func (id *diffInfo) captureAllGroups(deletion, insertion diffmatchpatch.Diff) error {
 	// Quick sanity check
@@ -232,27 +236,9 @@ func (id *diffInfo) captureAllGroups(deletion, insertion diffmatchpatch.Diff) er
 	return nil
 }
 
-// Perform the diff, ensuring the diff parts are on word-boundaries, and
-// recording the parts in id.diffs
-func (id *diffInfo) doWordDiff(pattern, value string) {
-	id.dmp = diffmatchpatch.New()
-	diffs := id.dmp.DiffMain(pattern, value, false)
-	// Note: This DiffCleanupSemantic() helper will ensure we don't split any
-	// capture groups into peices provided there is no space in any of them
-	// (which is why we enforce this in 'Validate' below)
-	// TODO: If we implemented an alternative to this that respected full
-	// capture groups and not just word boundaries, that would allow spaces in
-	// capture groups.
-	id.diffs = id.dmp.DiffCleanupSemantic(diffs)
-}
-
-// Perform the diff, ensuring the diff parts are on line-boundaries, and
-// recording the parts in id.diffs
-func (id *diffInfo) doLineDiff(pattern, value string) {
-	id.dmp = diffmatchpatch.New()
-	patternLines, valueLines, lineStrings := id.dmp.DiffLinesToChars(pattern, value)
-	diffs := id.dmp.DiffMain(patternLines, valueLines, true)
-	id.diffs = id.dmp.DiffCharsToLines(diffs, lineStrings)
+// Perform the diff or a per-character basis, recording the parts in id.diffs
+func (id *diffInfo) doDiff(pattern, value string) {
+	id.diffs = id.dmp.DiffMain(pattern, value, false)
 }
 
 // Return the potentially-comparable diff pair to id.diffs[i] (ie, if
@@ -273,22 +259,57 @@ func (id *diffInfo) comparableDiffPair(i int) (*diffmatchpatch.Diff, *diffmatchp
 	return nil, nil
 }
 
+func (id *diffInfo) escapeCaptureGroups(pattern string) (string, map[rune]string) {
+	escapes := make(map[rune]string)
+	replacedPatternBuilder := strings.Builder{}
+	idx := 0
+	replacementRune := '\U000F0000' // Private Use Area-A starting point
+	for _, group := range id.cg {
+		if idx < group.Start {
+			replacedPatternBuilder.WriteString(pattern[idx:group.Start])
+		}
+		escapes[replacementRune] = group.Full
+		replacedPatternBuilder.WriteRune(replacementRune)
+		replacementRune++
+		idx = group.End
+	}
+	if idx < len(pattern) {
+		replacedPatternBuilder.WriteString(pattern[idx:])
+	}
+	return replacedPatternBuilder.String(), escapes
+}
+
+func (id *diffInfo) unescapeCaptureGroupDiffs(escapes map[rune]string) {
+	// With the main diff complete, replace the placeholder runes with the real capturegroups
+	fixedDiffs := make([]diffmatchpatch.Diff, len(id.diffs))
+	for i, diff := range id.diffs {
+		fixedBuilder := strings.Builder{}
+		for _, r := range diff.Text {
+			if v, ok := escapes[r]; ok {
+				fixedBuilder.WriteString(v)
+			} else {
+				fixedBuilder.WriteRune(r)
+			}
+		}
+		diff.Text = fixedBuilder.String()
+		fixedDiffs[i] = diff
+	}
+	id.diffs = fixedDiffs
+}
+
 // Main entrypoint called by compare.go
 func (id CapturegroupsInlineDiff) Diff(pattern, value string, sharedCapturedValues CapturedValues) (string, CapturedValues) {
 	// General approach:
 	//  - Match all relevant capturegroups
 	//  - Substitute in the values for all matched capturegroups to the pattern
 
-	cgDiff := diffInfo{CapturedValues: sharedCapturedValues}
+	cgDiff := NewDiffInfo(pattern, sharedCapturedValues)
 
-	// Doing a word-wise diff shrinks the probleset by avoiding any text that
-	// is identical or an obvious plain deletion or addition.
-	if diffByLines {
-		cgDiff.doLineDiff(pattern, value)
-	} else {
-		// First do a word-wise diff to isolate only those whole words that differ
-		cgDiff.doWordDiff(pattern, value)
-	}
+	// In order to not have capturegroups partially consumed by the diff algorithm, replace all capturegroups with placeholders in the Unicode Private Use Area (\uF0000)
+	replacedPattern, escapes := cgDiff.escapeCaptureGroups(pattern)
+	cgDiff.doDiff(replacedPattern, value)
+	// With the main diff complete, replace the placeholder runes with the real capturegroups
+	cgDiff.unescapeCaptureGroupDiffs(escapes)
 
 	// Next, look for any interesting insert-then-delete or delete-then-insert
 	// adjacent sections, and try to match any capturegroups we find.
@@ -313,7 +334,7 @@ func (id CapturegroupsInlineDiff) Diff(pattern, value string, sharedCapturedValu
 	// - any different values matched to the same-named capturegroups as different
 	reconciledString := ""
 	idx := 0
-	for _, group := range CapturegroupIndex(pattern) {
+	for _, group := range cgDiff.cg {
 		if idx < group.Start {
 			reconciledString += pattern[idx:group.Start]
 		}

--- a/pkg/compare/capturegroupsInlineDiff.go
+++ b/pkg/compare/capturegroupsInlineDiff.go
@@ -60,6 +60,7 @@ type diffInfo struct {
 
 type CgInfo struct {
 	Name  string
+	Full  string
 	Start int
 	End   int
 }
@@ -132,6 +133,7 @@ func CapturegroupIndex(pattern string) []CgInfo {
 			if pDepth < 0 {
 				// Exited this capture group; record it
 				cg.End = i + 1
+				cg.Full = pattern[cg.Start:cg.End]
 				result = append(result, cg)
 				break
 			}

--- a/pkg/compare/capturegroupsInlineDiff.go
+++ b/pkg/compare/capturegroupsInlineDiff.go
@@ -370,14 +370,6 @@ func (id CapturegroupsInlineDiff) Validate(pattern string) error {
 			errs = errors.Join(errs, fmt.Errorf("line %d %w", i+1, err))
 			continue
 		}
-		// Furthermore, ensure each capturegroup has no spaces or linebreaks
-		// inside (because otherwise the DiffCleanupSemantic() above may split
-		// it and render it useless)
-		for _, group := range groups {
-			if strings.ContainsAny(line[group.Start:group.End], " \n") {
-				errs = errors.Join(errs, fmt.Errorf("line %d:%d capturegroup contains spaces or linebreaks", i+1, group.Start))
-			}
-		}
 	}
 	return errs
 }

--- a/pkg/compare/capturegroupsInlineDiff.go
+++ b/pkg/compare/capturegroupsInlineDiff.go
@@ -197,6 +197,8 @@ func (id *diffInfo) captureAllGroups(deletion, insertion diffmatchpatch.Diff) er
 	// The insert side is the value we're matching against
 	value := insertion.Text
 
+	klog.V(1).Infof("Comparing Pattern '%s' to value '%s'", pattern, value)
+
 	// Find all capturegroups in the pattern
 	groups := CapturegroupIndex(pattern)
 	if len(groups) == 0 {

--- a/pkg/compare/capturegroupsInlineDiff_test.go
+++ b/pkg/compare/capturegroupsInlineDiff_test.go
@@ -43,6 +43,7 @@ func TestCapturegroupIndex(t *testing.T) {
 					nameEnd := strings.Index(expected, ">")
 					expectedName := expected[3:nameEnd]
 					assert.Equal(t, expectedName, m.Name, fmt.Sprintf("Expected capture group %d name match", i))
+					assert.Equal(t, expected, m.Full, fmt.Sprintf("Expected full capturegroup %d", i))
 				})
 			}
 		})

--- a/pkg/compare/capturegroupsInlineDiff_test.go
+++ b/pkg/compare/capturegroupsInlineDiff_test.go
@@ -31,6 +31,7 @@ func TestCapturegroupIndex(t *testing.T) {
 		{"(?<group_with_groups>(?<inner1>.*(?<inner2>.*))?)", []string{"(?<group_with_groups>(?<inner1>.*(?<inner2>.*))?)"}},
 		{"(?<one>.*)(?<two>.*)", []string{"(?<one>.*)", "(?<two>.*)"}},
 		{"Two groups (?<first>.*) in a (?<second>.*) string", []string{"(?<first>.*)", "(?<second>.*)"}},
+		{"Space in a (?<cg>[a-zA-Z ]+ etc) group", []string{"(?<cg>[a-zA-Z ]+ etc)"}},
 	}
 	for _, c := range tests {
 		t.Run(fmt.Sprintf("Pattern %q", c.pattern), func(t *testing.T) {
@@ -396,5 +397,42 @@ func TestCapturegroupsDiff(t *testing.T) {
 				})
 			}
 		})
+	}
+}
+
+func TestCapturegroupsValidate(t *testing.T) {
+	suites := []struct {
+		pattern     string
+		expectError bool
+	}{
+		{
+			pattern:     "",
+			expectError: false,
+		},
+		{
+			pattern:     "No regex",
+			expectError: false,
+		},
+		{
+			pattern:     "No capturegroups (.*) but some regex",
+			expectError: false,
+		},
+		{
+			pattern:     "Simple capturegroup (?<named>.*)",
+			expectError: false,
+		},
+		{
+			pattern:     "Broken capturegroup (?<named>[[:_broken_character_class_name_:]])",
+			expectError: true,
+		},
+	}
+	for _, s := range suites {
+		cg := CapturegroupsInlineDiff{}
+		err := cg.Validate(s.pattern)
+		if s.expectError {
+			assert.Error(t, err, s.pattern)
+		} else {
+			assert.NoError(t, err, s.pattern)
+		}
 	}
 }

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io/fs"
 	"os"
@@ -668,6 +669,16 @@ func (o *Options) Run() error {
 		ContinueOnError().
 		Flatten().
 		Do()
+
+	// Adjust klog to match '--verbose' flag
+	klogVerbosity := "0"
+	if o.verboseOutput {
+		klogVerbosity = "1"
+	}
+	flagSet := flag.NewFlagSet("test", flag.ExitOnError)
+	klog.InitFlags(flagSet)
+	_ = flagSet.Parse([]string{"--v", klogVerbosity})
+
 	if err := r.Err(); err != nil {
 		return fmt.Errorf("failed to collect resources: %w", err)
 	}

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -688,6 +688,7 @@ func (o *Options) Run() error {
 			return true
 		}
 		if strings.Contains(err.Error(), "error parsing") {
+			// TODO: Fix this error message truncation
 			klog.Warningf(skipInvalidResources, extractPath(err.Error(), 2), err.Error()[strings.LastIndex(err.Error(), ":"):])
 			return true
 		}

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localinvalidCapturegroupsLateDetectionout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localinvalidCapturegroupsLateDetectionout.golden
@@ -1,4 +1,4 @@
-Skipping during Input contains additional files from supported file extensions (json/yaml) that do not contain a valid resource, error: :18 capturegroup contains spaces or linebreaks.
+Skipping during Input contains additional files from supported file extensions (json/yaml) that do not contain a valid resource, error: :]`.
  In case this file is expected to be a valid resource modify it accordingly. 
 Summary
 CRs with diffs: 0/0

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localinvalidCapturegroupserr.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localinvalidCapturegroupserr.golden
@@ -1,3 +1,3 @@
 error: reference contains template with config per field with InlineDiffFunc that fails validation. InlineDiffFunc: capturegroups. error: line 2 error parsing regexp: invalid named capture: `(?<username[a-z0-9]+) would put in their own name. (?<username>`
-line 3:18 capturegroup contains spaces or linebreaks
+line 3 error parsing regexp: invalid character class range: `[:_broken_capturegroup_:]`
 error code:2

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/cm-invalid-capturegroups-late-detection.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/cm-invalid-capturegroups-late-detection.yaml
@@ -11,5 +11,5 @@ spec:
     - bigTextBlock: |-
         This is a big text block with some static content, like this line.
         It also has a place where (?<username[a-z0-9]+) would put in their own name. (?<username>[a-z0-9]+) would put in their own name.
-        More complicated [(?<group>[^a-z A-Z]+)] are also allowed.
+        More complicated [(?<group>[[:_broken_capturegroup_:]]+)] are also allowed.
     {{- end }}

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/cm-invalid-capturegroups.yaml
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/reference/cm-invalid-capturegroups.yaml
@@ -10,4 +10,4 @@ spec:
     - bigTextBlock: |-
         This is a big text block with some static content, like this line.
         It also has a place where (?<username[a-z0-9]+) would put in their own name. (?<username>[a-z0-9]+) would put in their own name.
-        More complicated [(?<group>[^a-z A-Z]+)] are also allowed.
+        More complicated [(?<group>[[:_broken_capturegroup_:]]+)] are also allowed.


### PR DESCRIPTION
- **Add capturegroup debugging details to verbose output**
- **Add full capturegroup text to CgInfo structure**
- **Implement better capturegroup escape mechanism**
- **Allow spaces in capturegroup regexes**
