### PR TITLE
OCPBUGS-53199: Use diff size as multi-match tiebreaker

### DIFF
--- a/pkg/compare/capturegroupsInlineDiff.go
+++ b/pkg/compare/capturegroupsInlineDiff.go
@@ -203,14 +203,14 @@ func (id *diffInfo) captureAllGroups(deletion, insertion diffmatchpatch.Diff) er
 	// The insert side is the value we're matching against
 	value := insertion.Text
 
-	klog.V(1).Infof("Comparing Pattern '%s' to value '%s'", pattern, value)
-
 	// Find all capturegroups in the pattern
 	groups := CapturegroupIndex(pattern)
 	if len(groups) == 0 {
 		// No groups to match
 		return nil
 	}
+
+	klog.V(1).Infof("Comparing Pattern '%s' to value '%s'", pattern, value)
 
 	// Quote all text that surrounds the capturegroups
 	quotedPattern := CapturegroupQuoteMeta(pattern, groups)

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -17,6 +17,7 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/gosimple/slug"
+	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -542,42 +543,15 @@ func extractPath(str string, pathIndex int) string {
 	return "Unknown Path"
 }
 
-func countLeaf(d any) int {
-	count := 0
-	switch t := d.(type) {
-	case map[string]any:
-		for _, v := range t {
-			count += countLeaf(v)
-		}
-	case []any:
-		for _, v := range t {
-			count += countLeaf(v)
-		}
-	default:
-		return 1
-	}
-	return count
-}
-
-func countLeaves(uo *UserOverride) (int, error) {
-	var data map[string]any
-	err := json.Unmarshal([]byte(uo.Patch), &data)
-	if err != nil {
-		return 0, fmt.Errorf("failed to unmarshal internal diff: %w", err)
-	}
-	return countLeaf(data), nil
-}
-
 func findBestMatch(matches []*diffResult) *diffResult {
-	var bestLeafMatch *diffResult
+	var bestMatch *diffResult
 	for _, match := range matches {
-		klog.V(1).Infof(" - %s -> %d fields different", match.temp.GetPath(), match.leafCount)
-		if bestLeafMatch == nil || match.leafCount < bestLeafMatch.leafCount {
-			bestLeafMatch = match
+		klog.V(1).Infof(" - %s - Diff score: %d", match.temp.GetPath(), match.diffScore)
+		if bestMatch == nil || match.diffScore < bestMatch.diffScore {
+			bestMatch = match
 		}
 	}
-	return bestLeafMatch
-
+	return bestMatch
 }
 
 func getBestMatchByLines(templates []ReferenceTemplate, cr *unstructured.Unstructured, userOverrides []*UserOverride, o *Options) (*diffResult, error) {
@@ -611,11 +585,11 @@ type diffResult struct {
 	userOverride *UserOverride
 	temp         ReferenceTemplate
 	crname       string
-	leafCount    int
+	diffScore    int
 }
 
 func (d diffResult) IsDiff() bool {
-	res := d.leafCount > 0
+	res := d.diffScore > 0
 	if !res && d.exitError != nil && d.exitError.ExitStatus() == 1 {
 		klog.Warningf("%s: Internally we found no difference but the external tool responded with an exit code of 1", d.crname)
 	}
@@ -635,18 +609,16 @@ func diffAgainstTemplate(temp ReferenceTemplate, clusterCR *unstructured.Unstruc
 		temp:   temp,
 	}
 
-	localRef, err := temp.Exec(clusterCR.Object)
-	if err != nil {
-		return res, err //nolint: wrapcheck
-	}
 	obj := InfoObject{
-		templateSource:          temp.GetPath(),
-		injectedObjFromTemplate: localRef,
-		clusterObj:              clusterCR,
-		FieldsToOmit:            temp.GetFieldsToOmit(o.ref.GetFieldsToOmit()),
-		allowMerge:              temp.GetConfig().GetAllowMerge(),
-		userOverrides:           userOverrides,
-		templateFieldConf:       temp.GetConfig().GetInlineDiffFuncs(),
+		templateSource:    temp.GetPath(),
+		FieldsToOmit:      temp.GetFieldsToOmit(o.ref.GetFieldsToOmit()),
+		allowMerge:        temp.GetConfig().GetAllowMerge(),
+		userOverrides:     userOverrides,
+		templateFieldConf: temp.GetConfig().GetInlineDiffFuncs(),
+	}
+	err := obj.initializeObjData(temp, clusterCR)
+	if err != nil {
+		return res, fmt.Errorf("template injection failed: %w", err)
 	}
 
 	differ, err := diff.NewDiffer("MERGED", "LIVE")
@@ -672,19 +644,35 @@ func diffAgainstTemplate(temp ReferenceTemplate, clusterCR *unstructured.Unstruc
 		return res, fmt.Errorf("diff exited with non-zero code: %w", err)
 	}
 
-	// Some extra metadata for deciding if its a good diff
+	// Construct a diffScore based on a diffmatchpatch character-wise diff.
+	// The score is used to decide which of multiple matches is the best match.
+	dmp := diffmatchpatch.New()
+	templateData, err := os.ReadFile(filepath.Join(differ.From.Dir.Name, obj.Name()))
+	if err != nil {
+		return res, fmt.Errorf("readback of diff From object: %w", err)
+	}
+	crData, err := os.ReadFile(filepath.Join(differ.To.Dir.Name, obj.Name()))
+	if err != nil {
+		return res, fmt.Errorf("readback of diff To object: %w", err)
+	}
+	diffs := dmp.DiffMain(string(templateData), string(crData), false)
+	count := 0
+	for _, diff := range diffs {
+		if diff.Type != diffmatchpatch.DiffEqual {
+			count += len(diff.Text)
+		}
+	}
+	res.diffScore = count
+
+	// Create the user override MergePatch for later use
+	// TODO: This is based on obj.Live() and obj.Merged() which may be
+	// marginally different than the differ-written files used in the two prior
+	// steps.
 	uo, err := CreateMergePatch(temp, &obj, o.overrideReason)
-	// if user override is ok we can count the leaves in the patches
 	if err != nil {
 		return res, err
 	}
 	res.userOverride = uo
-
-	count, err := countLeaves(uo)
-	if err != nil {
-		return res, err
-	}
-	res.leafCount = count
 
 	return res, nil
 }
@@ -824,7 +812,6 @@ type InfoObject struct {
 
 // Live Returns the cluster version of the object
 func (obj InfoObject) Live() runtime.Object {
-	omitFields(obj.clusterObj.Object, obj.FieldsToOmit)
 	return obj.clusterObj
 }
 
@@ -837,29 +824,42 @@ func (e MergeError) Error() string {
 	return fmt.Sprintf("failed to properly merge the manifests for %s some diff may be incorrect: %s", e.obj.Name(), e.err)
 }
 
-// Merged Returns the Injected Reference Version of the Resource
-func (obj InfoObject) Merged() (runtime.Object, error) {
+// Initialize obj.clusterCR and obj.injectedObjFromTemplate
+func (obj *InfoObject) initializeObjData(temp ReferenceTemplate, clusterCR *unstructured.Unstructured) error {
+	obj.clusterObj = clusterCR
+	omitFields(obj.clusterObj.Object, obj.FieldsToOmit)
+
 	var err error
+	localRef, err := temp.Exec(clusterCR.Object)
+	if err != nil {
+		return err //nolint: wrapcheck
+	}
+	obj.injectedObjFromTemplate = localRef
 	if obj.allowMerge {
 		obj.injectedObjFromTemplate, err = MergeManifests(obj.injectedObjFromTemplate, obj.clusterObj)
 		if err != nil {
-			return obj.injectedObjFromTemplate, &MergeError{obj: &obj, err: err}
+			return &MergeError{obj: obj, err: err}
 		}
 	}
 
 	for _, override := range obj.userOverrides {
 		patched, err := override.Apply(obj.injectedObjFromTemplate, obj.clusterObj)
 		if err != nil {
-			return obj.injectedObjFromTemplate, err
+			return err
 		}
 		obj.injectedObjFromTemplate = patched
 	}
 	err = obj.runInlineDiffFuncs()
 	if err != nil {
-		return obj.injectedObjFromTemplate, &InlineDiffError{obj: &obj, err: err}
+		return &InlineDiffError{obj: obj, err: err}
 	}
 	omitFields(obj.injectedObjFromTemplate.Object, obj.FieldsToOmit)
-	return obj.injectedObjFromTemplate, err
+	return nil
+}
+
+// Merged Returns the Injected Reference Version of the Resource
+func (obj InfoObject) Merged() (runtime.Object, error) {
+	return obj.injectedObjFromTemplate, nil
 }
 
 type InlineDiffError struct {

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -571,6 +571,7 @@ func countLeaves(uo *UserOverride) (int, error) {
 func findBestMatch(matches []*diffResult) *diffResult {
 	var bestLeafMatch *diffResult
 	for _, match := range matches {
+		klog.V(1).Infof(" - %s -> %d fields different", match.temp.GetPath(), match.leafCount)
 		if bestLeafMatch == nil || match.leafCount < bestLeafMatch.leafCount {
 			bestLeafMatch = match
 		}
@@ -598,6 +599,7 @@ func getBestMatchByLines(templates []ReferenceTemplate, cr *unstructured.Unstruc
 		}
 		matches = append(matches, diffResult)
 	}
+	klog.V(1).Infof("Found %d matches for %s", len(matches), apiKindNamespaceName(cr))
 	return findBestMatch(matches), errors.Join(errs...)
 
 }
@@ -608,16 +610,17 @@ type diffResult struct {
 
 	userOverride *UserOverride
 	temp         ReferenceTemplate
+	crname       string
 	leafCount    int
 }
 
 func (d diffResult) IsDiff() bool {
 	res := d.leafCount > 0
 	if !res && d.exitError != nil && d.exitError.ExitStatus() == 1 {
-		klog.Warning("Internally we found no difference but the external tool responded with an exit code of 1")
+		klog.Warningf("%s: Internally we found no difference but the external tool responded with an exit code of 1", d.crname)
 	}
 	if res && d.exitError == nil {
-		klog.Warning("Internally we found a difference but the external tool responded with an exit code of 0")
+		klog.Warningf("%s: Internally we found a difference but the external tool responded with an exit code of 0", d.crname)
 	}
 	return res
 }
@@ -628,7 +631,8 @@ func (d diffResult) DiffOutput() *bytes.Buffer {
 
 func diffAgainstTemplate(temp ReferenceTemplate, clusterCR *unstructured.Unstructured, userOverrides []*UserOverride, o *Options) (*diffResult, error) {
 	res := &diffResult{
-		temp: temp,
+		crname: apiKindNamespaceName(clusterCR),
+		temp:   temp,
 	}
 
 	localRef, err := temp.Exec(clusterCR.Object)
@@ -636,6 +640,7 @@ func diffAgainstTemplate(temp ReferenceTemplate, clusterCR *unstructured.Unstruc
 		return res, err //nolint: wrapcheck
 	}
 	obj := InfoObject{
+		templateSource:          temp.GetPath(),
 		injectedObjFromTemplate: localRef,
 		clusterObj:              clusterCR,
 		FieldsToOmit:            temp.GetFieldsToOmit(o.ref.GetFieldsToOmit()),
@@ -808,6 +813,7 @@ func (o *Options) Run() error {
 
 // InfoObject matches the diff.Object interface, it contains the objects that shall be compared.
 type InfoObject struct {
+	templateSource          string
 	injectedObjFromTemplate *unstructured.Unstructured
 	clusterObj              *unstructured.Unstructured
 	FieldsToOmit            []*ManifestPathV1
@@ -915,6 +921,7 @@ func (obj InfoObject) runInlineDiffFuncs() error {
 			errs = append(errs, fmt.Errorf("failed to validate the inline diff for field %s, %w", pathToKey, err))
 			continue
 		}
+		klog.V(1).Infof("Performing %s comparison for %s::%s", inlineDiffFunc, obj.templateSource, pathToKey)
 		_, updatedCapturegroups := diffFn.Diff(value, clusterValue, sharedCapturegroups)
 		sharedCapturegroups = updatedCapturegroups
 		preprocessedValues = append(preprocessedValues, DiffValues{

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -511,6 +511,16 @@ func TestCompareRun(t *testing.T) {
 			withMetadataFile("metadata-one-of.yaml").
 			withChecks(defaultChecks.withPrefixedSuffix("oneOf")),
 
+		defaultTest("Multitemplate Tie Breaker"),
+		defaultTest("Multitemplate Tie Breaker").
+			withSubTestSuffix("Length Mismatch").
+			withMetadataFile("metadata-length-mismatch.yaml").
+			withChecks(defaultChecks.withPrefixedSuffix("lengthMismatch")),
+		defaultTest("Multitemplate Tie Breaker").
+			withSubTestSuffix("Field Mismatch").
+			withMetadataFile("metadata-field-mismatch.yaml").
+			withChecks(defaultChecks.withPrefixedSuffix("fieldMismatch")),
+
 		defaultTest("Reference V2 All").
 			withSubTestSuffix("All Of").
 			withMetadataFile("metadata-all-of.yaml").

--- a/pkg/compare/testdata/MultitemplateTieBreaker/localerr.golden
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/localerr.golden
@@ -1,0 +1,2 @@
+
+error code:1

--- a/pkg/compare/testdata/MultitemplateTieBreaker/localfieldMismatcherr.golden
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/localfieldMismatcherr.golden
@@ -1,0 +1,1 @@
+localerr.golden

--- a/pkg/compare/testdata/MultitemplateTieBreaker/localfieldMismatchout.golden
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/localfieldMismatchout.golden
@@ -1,0 +1,1 @@
+localout.golden

--- a/pkg/compare/testdata/MultitemplateTieBreaker/locallengthMismatcherr.golden
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/locallengthMismatcherr.golden
@@ -1,0 +1,1 @@
+localerr.golden

--- a/pkg/compare/testdata/MultitemplateTieBreaker/locallengthMismatchout.golden
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/locallengthMismatchout.golden
@@ -1,0 +1,1 @@
+localout.golden

--- a/pkg/compare/testdata/MultitemplateTieBreaker/localout.golden
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/localout.golden
@@ -1,0 +1,29 @@
+The reference contains overlapping object definitions which may result in unexpected correlation results. Re-run with '--verbose' output enabled to view a detailed description of the issues
+**********************************
+
+Cluster CR: v1_ConfigMap_default_settings
+Reference File: cm-correct.yaml
+Diff Output: diff -u -N TEMP/v1_configmap_default_settings TEMP/v1_configmap_default_settings
+--- TEMP/v1_configmap_default_settings	DATE
++++ TEMP/v1_configmap_default_settings	DATE
+@@ -1,9 +1,9 @@
+ apiVersion: v1
+ data:
+-  fieldOne: mismatch
++  fieldOne: valueOne
+   fieldTwo: |-
+     Multi-line string
+-    mismatch
++    valueTwo
+     Multi-line string
+ kind: ConfigMap
+ metadata:
+
+**********************************
+
+Summary
+CRs with diffs: 1/1
+No validation issues with the cluster
+No CRs are unmatched to reference CRs
+Metadata Hash: $METADATA_HASH$
+No patched CRs

--- a/pkg/compare/testdata/MultitemplateTieBreaker/reference/cm-correct.yaml
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/reference/cm-correct.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: settings
+  namespace: default
+data:
+  fieldOne: mismatch
+  fieldTwo: |-
+    Multi-line string
+    mismatch
+    Multi-line string

--- a/pkg/compare/testdata/MultitemplateTieBreaker/reference/cm-extra-field.yaml
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/reference/cm-extra-field.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: settings
+  namespace: default
+data:
+  fieldOne: mismatch
+  fieldTwo: |-
+    Multi-line string
+    mismatch
+    Multi-line string
+  fieldThree: mismatch

--- a/pkg/compare/testdata/MultitemplateTieBreaker/reference/cm-missing-field.yaml
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/reference/cm-missing-field.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: settings
+  namespace: default
+data:
+  fieldTwo: |-
+    Multi-line string
+    mismatch
+    Multi-line string

--- a/pkg/compare/testdata/MultitemplateTieBreaker/reference/cm-same-fields-too-long.yaml
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/reference/cm-same-fields-too-long.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: settings
+  namespace: default
+data:
+  fieldOne: mismatch
+  fieldTwo: |-
+    Multi-line string
+    This has a much larger difference with respect to the ConfigMap we're testing
+    mismatch
+    Multi-line string
+    Oh yes, many more differences.  We shouldn't choose this one; choose the other one

--- a/pkg/compare/testdata/MultitemplateTieBreaker/reference/cm-same-fields-too-short.yaml
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/reference/cm-same-fields-too-short.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: settings
+  namespace: default
+data:
+  fieldOne: mismatch
+  fieldTwo: |-
+    Multi-line string
+    mismatch

--- a/pkg/compare/testdata/MultitemplateTieBreaker/reference/metadata-field-mismatch.yaml
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/reference/metadata-field-mismatch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: Test
+        oneOf:
+          - path: cm-missing-field.yaml
+          - path: cm-correct.yaml
+          - path: cm-extra-field.yaml

--- a/pkg/compare/testdata/MultitemplateTieBreaker/reference/metadata-length-mismatch.yaml
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/reference/metadata-length-mismatch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: Test
+        oneOf:
+          - path: cm-same-fields-too-short.yaml
+          - path: cm-correct.yaml
+          - path: cm-same-fields-too-long.yaml

--- a/pkg/compare/testdata/MultitemplateTieBreaker/reference/metadata.yaml
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/reference/metadata.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: Test
+        oneOf:
+          - path: cm-same-fields-too-short.yaml
+          - path: cm-same-fields-too-long.yaml
+          - path: cm-correct.yaml
+          - path: cm-extra-field.yaml
+          - path: cm-missing-field.yaml

--- a/pkg/compare/testdata/MultitemplateTieBreaker/resources/cm.yaml
+++ b/pkg/compare/testdata/MultitemplateTieBreaker/resources/cm.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: settings
+  namespace: default
+data:
+  fieldOne: valueOne
+  fieldTwo: |-
+    Multi-line string
+    valueTwo
+    Multi-line string

--- a/pkg/compare/testdata/NoDiffs/localwithVebosityFlagout.golden
+++ b/pkg/compare/testdata/NoDiffs/localwithVebosityFlagout.golden
@@ -1,7 +1,7 @@
 Found 1 matches for apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
- - deploymentMetrics.yaml -> 0 fields different
+ - deploymentMetrics.yaml - Diff score: 0
 Found 1 matches for apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
- - deploymentDashboard.yaml -> 0 fields different
+ - deploymentDashboard.yaml - Diff score: 0
 **********************************
 
 Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard

--- a/pkg/compare/testdata/NoDiffs/localwithVebosityFlagout.golden
+++ b/pkg/compare/testdata/NoDiffs/localwithVebosityFlagout.golden
@@ -1,3 +1,7 @@
+Found 1 matches for apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
+ - deploymentMetrics.yaml -> 0 fields different
+Found 1 matches for apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
+ - deploymentDashboard.yaml -> 0 fields different
 **********************************
 
 Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard

--- a/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localinvalidCapturegroupsLateDetectionout.golden
+++ b/pkg/compare/testdata/ReferenceV2InlineCapturegroups/localinvalidCapturegroupsLateDetectionout.golden
@@ -1,4 +1,4 @@
-Skipping during Input contains additional files from supported file extensions (json/yaml) that do not contain a valid resource, error: :]`.
+Skipping failed: Input contains additional files from supported file extensions (json/yaml) that do not contain a valid resource, error: :]`.
  In case this file is expected to be a valid resource modify it accordingly. 
 Summary
 CRs with diffs: 0/0

--- a/pkg/compare/testdata/ReferenceV2PerFieldMatcherValidation/localpathNotItTemplateerr.golden
+++ b/pkg/compare/testdata/ReferenceV2PerFieldMatcherValidation/localpathNotItTemplateerr.golden
@@ -1,2 +1,2 @@
-error: error occurred while trying to process resources: error occurered during diff: failed to properly run inline diff functions for v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings some diff may be incorrect: failed to acces value in template of field spec.bigTextBloc that uses inline diff func: Not found
+error: error occurred while trying to process resources: template injection failed: failed to properly run inline diff functions for v1_configmap_kubernetes-dashboard_kubernetes-dashboard-settings some diff may be incorrect: failed to acces value in template of field spec.bigTextBloc that uses inline diff func: Not found
 error code:2

--- a/pkg/compare/testdata/SomeDiffs/localwithVebosityFlagout.golden
+++ b/pkg/compare/testdata/SomeDiffs/localwithVebosityFlagout.golden
@@ -1,3 +1,7 @@
+Found 1 matches for apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
+ - deploymentMetrics.yaml -> 1 fields different
+Found 1 matches for apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
+ - deploymentDashboard.yaml -> 0 fields different
 **********************************
 
 Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard

--- a/pkg/compare/testdata/SomeDiffs/localwithVebosityFlagout.golden
+++ b/pkg/compare/testdata/SomeDiffs/localwithVebosityFlagout.golden
@@ -1,7 +1,7 @@
 Found 1 matches for apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
- - deploymentMetrics.yaml -> 1 fields different
+ - deploymentMetrics.yaml - Diff score: 5
 Found 1 matches for apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
- - deploymentDashboard.yaml -> 0 fields different
+ - deploymentDashboard.yaml - Diff score: 0
 **********************************
 
 Cluster CR: apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard

--- a/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localVerboseout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localVerboseout.golden
@@ -1,4 +1,7 @@
 More than one template with same apiVersion, metadata_namespace, kind. By Default for each Cluster CR that is correlated to one of these templates the template with the least number of diffs will be used. To use a different template for a specific CR specify it in the diff-config (-c flag) Template names are: apps.v1.DaemonSet.kube-system.kindnet.yaml, apps.v1.DaemonSet.kube-system.kindnet2.yaml
+Found 2 matches for apps/v1_DaemonSet_SomeNS_Name
+ - apps.v1.DaemonSet.kube-system.kindnet.yaml -> 1 fields different
+ - apps.v1.DaemonSet.kube-system.kindnet2.yaml -> 2 fields different
 **********************************
 
 Cluster CR: apps/v1_DaemonSet_SomeNS_Name

--- a/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localVerboseout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localVerboseout.golden
@@ -1,7 +1,7 @@
 More than one template with same apiVersion, metadata_namespace, kind. By Default for each Cluster CR that is correlated to one of these templates the template with the least number of diffs will be used. To use a different template for a specific CR specify it in the diff-config (-c flag) Template names are: apps.v1.DaemonSet.kube-system.kindnet.yaml, apps.v1.DaemonSet.kube-system.kindnet2.yaml
 Found 2 matches for apps/v1_DaemonSet_SomeNS_Name
- - apps.v1.DaemonSet.kube-system.kindnet.yaml -> 1 fields different
- - apps.v1.DaemonSet.kube-system.kindnet2.yaml -> 2 fields different
+ - apps.v1.DaemonSet.kube-system.kindnet.yaml - Diff score: 13
+ - apps.v1.DaemonSet.kube-system.kindnet2.yaml - Diff score: 14
 **********************************
 
 Cluster CR: apps/v1_DaemonSet_SomeNS_Name

--- a/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localVerboseout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localVerboseout.golden
@@ -1,4 +1,7 @@
 More than one template with same apiVersion, metadata_name, metadata_namespace, kind. By Default for each Cluster CR that is correlated to one of these templates the template with the least number of diffs will be used. To use a different template for a specific CR specify it in the diff-config (-c flag) Template names are: apps.v1.DaemonSet.kube-system.kindnet.yaml, apps.v1.DaemonSet.kube-system.kindnet.yaml
+Found 2 matches for apps/v1_DaemonSet_SomeNS_Name
+ - apps.v1.DaemonSet.kube-system.kindnet.yaml -> 0 fields different
+ - apps.v1.DaemonSet.kube-system.kindnet.yaml -> 0 fields different
 **********************************
 
 Cluster CR: apps/v1_DaemonSet_SomeNS_Name

--- a/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localVerboseout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localVerboseout.golden
@@ -1,7 +1,7 @@
 More than one template with same apiVersion, metadata_name, metadata_namespace, kind. By Default for each Cluster CR that is correlated to one of these templates the template with the least number of diffs will be used. To use a different template for a specific CR specify it in the diff-config (-c flag) Template names are: apps.v1.DaemonSet.kube-system.kindnet.yaml, apps.v1.DaemonSet.kube-system.kindnet.yaml
 Found 2 matches for apps/v1_DaemonSet_SomeNS_Name
- - apps.v1.DaemonSet.kube-system.kindnet.yaml -> 0 fields different
- - apps.v1.DaemonSet.kube-system.kindnet.yaml -> 0 fields different
+ - apps.v1.DaemonSet.kube-system.kindnet.yaml - Diff score: 0
+ - apps.v1.DaemonSet.kube-system.kindnet.yaml - Diff score: 0
 **********************************
 
 Cluster CR: apps/v1_DaemonSet_SomeNS_Name


### PR DESCRIPTION
- **Tighten up verbose messages for comparison and correlation debugging**
- **Use a diffscore and not mergepatch leafCount to decide between multiple matches**
