### PR TITLE
CNF-16041: Add 'lookupCR' and 'lookupCRs' template functions for cross-object references

### DIFF
--- a/addon-tools/helm-convert/convert/testdata/LookupSubstitution/reference/cm.yaml
+++ b/addon-tools/helm-convert/convert/testdata/LookupSubstitution/reference/cm.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: downstream
+  namespace: default
+data:
+  {{- $objList := lookupCRs "v1" "ConfigMap" "default" "*" }}
+  {{- $plainObj := lookupCR "v1" "ConfigMap" "default" "single" }}
+  {{- $value := "not found" }}
+  {{- if $objList }}
+    {{- $firstObj := index $objList 0 }}
+    {{- $value = index $firstObj "data" "fieldname" }}
+  {{- end }}
+  value1: {{ $value | toYaml }}
+  value2: {{ $plainObj.data.fieldname | toYaml }}

--- a/addon-tools/helm-convert/convert/testdata/LookupSubstitution/reference/metadata.yaml
+++ b/addon-tools/helm-convert/convert/testdata/LookupSubstitution/reference/metadata.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: Example
+        allOf:
+          - path: cm.yaml

--- a/addon-tools/helm-convert/convert/testdata/LookupSubstitution/result/Chart.yaml
+++ b/addon-tools/helm-convert/convert/testdata/LookupSubstitution/result/Chart.yaml
@@ -1,0 +1,3 @@
+description: This Helm Chart was generated from a kube-compare reference
+name: Lookup Substitution
+version: "1"

--- a/addon-tools/helm-convert/convert/testdata/LookupSubstitution/result/templates/cm.yaml
+++ b/addon-tools/helm-convert/convert/testdata/LookupSubstitution/result/templates/cm.yaml
@@ -1,0 +1,23 @@
+{{- $values := list (dict)}}
+{{- if .Values.cm}}
+{{- $values = .Values.cm }}
+{{- end }}
+{{- range $values -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: downstream
+  namespace: default
+data:
+  {{- $objList := ($.Values.global.lookup_substitutions.lookupCRs_v1_ConfigMap_default) }}
+  {{- $plainObj := ($.Values.global.lookup_substitutions.lookupCR_v1_ConfigMap_default_single) }}
+  {{- $value := "not found" }}
+  {{- if $objList }}
+    {{- $firstObj := index $objList 0 }}
+    {{- $value = index $firstObj "data" "fieldname" }}
+  {{- end }}
+  value1: {{ $value | toYaml }}
+  value2: {{ $plainObj.data.fieldname | toYaml }}
+ 
+{{ end -}}

--- a/addon-tools/helm-convert/convert/testdata/LookupSubstitution/result/values.yaml
+++ b/addon-tools/helm-convert/convert/testdata/LookupSubstitution/result/values.yaml
@@ -1,0 +1,12 @@
+cm:
+- {}
+global:
+  lookup_substitutions:
+    lookupCR_v1_ConfigMap_default_single:
+      data:
+        fieldname: single value
+    lookupCRs_v1_ConfigMap_default:
+    - data:
+        fieldname: first substituted value
+    - data:
+        fieldname: second substituted value

--- a/addon-tools/helm-convert/convert/testdata/LookupSubstitution/values.yaml
+++ b/addon-tools/helm-convert/convert/testdata/LookupSubstitution/values.yaml
@@ -1,0 +1,12 @@
+global:
+  lookup_substitutions:
+    lookupCRs_v1_ConfigMap_default:    
+    - data:
+        fieldname: first substituted value
+    - data:
+        fieldname: second substituted value
+    lookupCR_v1_ConfigMap_default_single:
+      data:
+        fieldname: single value
+cm:
+- {}

--- a/docs/reference-config-guide-v2.md
+++ b/docs/reference-config-guide-v2.md
@@ -174,6 +174,53 @@ spec:
     {{- end }}
 ```
 
+### Additional template functions
+
+These custom functions add capabilities beyond the capabilities of the sprig or
+helm templates.
+
+#### lookupCRs
+
+Search for external structured objects.
+
+Usage:
+
+```yaml
+{{- $objlist := lookupCRs "$apiVersion" "$kind" "$namespace" "$name" }}
+```
+
+Returns a list of matching objects.  The `$apiVersion` and `$kind` arguments are
+required.  Both `$namespace` and `$name` can be blank or have the value `*`
+to match any namespace or name.
+
+This can be used within a template to represent a relationship between the
+object being matched and another separate object elsewhere.  Note: Only other
+objects that have templates to match in the current reference will be found -
+This cannot look up arbitrary objects on a cluster.  Likewise, when running in
+offline mode (with the `-f` option), only objects already in the file system
+paths specified are in scope to be found by this function.
+
+#### lookupCR
+
+Search for a singular structured object.
+
+Usage:
+
+```yaml
+{{- $obj := lookupCR "$apiVersion" "$kind" "$namespace" "$name" }}
+```
+
+or
+
+```yaml
+field: {{ (lookupCR "$apiVersion" "$kind" "$namespace" "$name").spec.replicas }}
+```
+
+Returns the matching object if there is exactly one.  The `$apiVersion` and
+`$kind` arguments are required.  Both `$namespace` and `$name` can be blank or
+have the value `*` to match any namespace or name.  If multiple objects are
+matched, this returns `nil`.
+
 ## Per-template configuration
 
 ### Pre-merging

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -733,6 +733,9 @@ func (o *Options) Run() error {
 		clusterCRs[i] = &unstructured.Unstructured{Object: clusterCRMapping}
 	}
 
+	// Load all CRs for the lookup function:
+	AllCRs = clusterCRs
+
 	process := func(clusterCR *unstructured.Unstructured) error {
 		temps, err := o.correlator.Match(clusterCR)
 		if err != nil && (!containOnly(err, []error{UnknownMatch{}}) || o.diffAll) {
@@ -846,6 +849,7 @@ func (obj *InfoObject) initializeObjData(temp ReferenceTemplate, clusterCR *unst
 	omitFields(obj.clusterObj.Object, obj.FieldsToOmit)
 
 	var err error
+	klog.V(1).Infof("Executing template %s", temp.GetPath())
 	localRef, err := temp.Exec(clusterCR.Object)
 	if err != nil {
 		return err //nolint: wrapcheck

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -660,6 +660,11 @@ func TestCompareRun(t *testing.T) {
 			withEnvVar("KUBECTL_EXTERNAL_DIFF", "diff -y -W 150").
 			withChecks(defaultChecks.withPrefixedSuffix("with_diff_y")),
 		defaultTest("Machine Configs Catch All"),
+
+		defaultTest("LookupCRs"),
+		defaultTest("LookupCRs").
+			withSubTestSuffix("LookupCR").
+			withMetadataFile("metadata-lookupCR.yaml"),
 	}
 
 	tf := cmdtesting.NewTestFactory()

--- a/pkg/compare/correlator.go
+++ b/pkg/compare/correlator.go
@@ -115,7 +115,7 @@ type GroupCorrelator[T CorrelationEntry] struct {
 // For fieldsGroups =  {{{"metadata", "namespace"}, {"kind"}}, {{"kind"}}} and the following templates: [fixedKindTemplate, fixedNamespaceKindTemplate]
 // the fixedNamespaceKindTemplate will be added to a mapping where the keys are  in the format of `namespace_kind`. The fixedKindTemplate
 // will be added to a mapping where the keys are  in the format of `kind`.
-func NewGroupCorrelator[T CorrelationEntry](fieldGroups [][][]string, objects []T, verboseOutput bool) (*GroupCorrelator[T], error) {
+func NewGroupCorrelator[T CorrelationEntry](fieldGroups [][][]string, objects []T) (*GroupCorrelator[T], error) {
 	sort.Slice(fieldGroups, func(i, j int) bool {
 		return len(fieldGroups[i]) >= len(fieldGroups[j])
 	})
@@ -134,7 +134,7 @@ func NewGroupCorrelator[T CorrelationEntry](fieldGroups [][][]string, objects []
 
 		err := fc.ValidateTemplates()
 		if err != nil {
-			if verboseOutput {
+			if klog.V(1).Enabled() {
 				klog.Warning(err)
 			} else {
 				klog.Warning("The reference contains overlapping object definitions which may result in unexpected correlation results. Re-run with '--verbose' output enabled to view a detailed description of the issues")

--- a/pkg/compare/referenceV1.go
+++ b/pkg/compare/referenceV1.go
@@ -353,6 +353,7 @@ func ParseV1Templates(ref *ReferenceV1, fsys fs.FS) ([]ReferenceTemplate, error)
 			}
 		}
 		temp.Template = parsedTemp
+		klog.V(1).Infof("Pre-processing template %s with empty data", temp.GetPath())
 		temp.metadata, err = temp.Exec(map[string]any{}) // Extract Metadata
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to parse template %s with empty data: %w", temp.Path, err))

--- a/pkg/compare/referenceV2.go
+++ b/pkg/compare/referenceV2.go
@@ -609,6 +609,7 @@ func ParseV2Templates(ref *ReferenceV2, fsys fs.FS) ([]ReferenceTemplate, error)
 		}
 		temp.Template = parsedTemp
 		temp.ReferenceTemplateV1.Config = temp.Config.ReferenceTemplateConfigV1
+		klog.V(1).Infof("Pre-processing template %s with empty data", temp.GetPath())
 		temp.metadata, err = temp.Exec(map[string]any{}) // Extract Metadata
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to parse template %s with empty data: %w", temp.Path, err))

--- a/pkg/compare/testdata/LookupCRs/localout.golden
+++ b/pkg/compare/testdata/LookupCRs/localout.golden
@@ -1,0 +1,6 @@
+Summary
+CRs with diffs: 0/3
+No validation issues with the cluster
+No CRs are unmatched to reference CRs
+Metadata Hash: $METADATA_HASH$
+No patched CRs

--- a/pkg/compare/testdata/LookupCRs/reference/cm-lookupCR.yaml
+++ b/pkg/compare/testdata/LookupCRs/reference/cm-lookupCR.yaml
@@ -1,0 +1,10 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard
+data:
+  dashboard: {{ index (lookupCR "apps/v1" "Deployment" "kubernetes-dashboard" "kubernetes-dashboard") "metadata" "name" | toYaml }}
+  metrics: {{ (lookupCR "apps/v1" "Deployment" "kubernetes-dashboard" "dashboard-metrics-scraper").metadata.name | toYaml }}

--- a/pkg/compare/testdata/LookupCRs/reference/cm-lookupCRs.yaml
+++ b/pkg/compare/testdata/LookupCRs/reference/cm-lookupCRs.yaml
@@ -1,0 +1,22 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard
+data:
+  {{- $objlist := lookupCRs "apps/v1" "Deployment" "kubernetes-dashboard" "*" }}
+  {{- $dashboardName := "unknown" }}
+  {{- $metricsName := "unknown" }}
+  {{- range $obj := $objlist }}
+    {{- $appname := index $obj "metadata" "labels" "k8s-app" }}
+    {{- if contains "metrics" $appname }}
+      {{- $metricsName = $obj.metadata.name }}
+    {{- end }}
+    {{- if eq "kubernetes-dashboard" $appname }}
+      {{- $dashboardName = $obj.metadata.name }}
+    {{- end }}
+  {{- end }}
+  dashboard: {{ $dashboardName }}
+  metrics: {{ $metricsName }}

--- a/pkg/compare/testdata/LookupCRs/reference/deploymentDashboard.yaml
+++ b/pkg/compare/testdata/LookupCRs/reference/deploymentDashboard.yaml
@@ -1,0 +1,66 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        k8s-app: kubernetes-dashboard
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubernetes-dashboard
+          image: kubernetesui/dashboard:v2.7.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+          args:
+            - --auto-generate-certificates
+            - --namespace=kubernetes-dashboard
+            # Uncomment the following line to manually specify Kubernetes API server Host
+            # If not specified, Dashboard will attempt to auto discover the API server and connect
+            # to it. Uncomment only if the default does not work.
+            # - --apiserver-host=http://my-address:port
+          volumeMounts:
+            - name: kubernetes-dashboard-certs
+              mountPath: /certs
+              # Create on-disk volume to store exec logs
+            - mountPath: /tmp
+              name: tmp-volume
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /
+              port: 8443
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
+      volumes:
+        - name: kubernetes-dashboard-certs
+          secret:
+            secretName: kubernetes-dashboard-certs
+        - name: tmp-volume
+          emptyDir: { }
+      serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "kubernetes.io/os": linux
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule

--- a/pkg/compare/testdata/LookupCRs/reference/deploymentMetrics.yaml
+++ b/pkg/compare/testdata/LookupCRs/reference/deploymentMetrics.yaml
@@ -1,0 +1,19 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper
+  namespace: kubernetes-dashboard
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: dashboard-metrics-scraper
+  template:
+    metadata:
+      labels:
+        k8s-app: dashboard-metrics-scraper
+    spec:
+{{ if .spec.template.spec }}{{ .spec.template.spec | toYaml | indent 6 }}{{ end }}

--- a/pkg/compare/testdata/LookupCRs/reference/metadata-lookupCR.yaml
+++ b/pkg/compare/testdata/LookupCRs/reference/metadata-lookupCR.yaml
@@ -1,0 +1,9 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: Dashboard
+        type: Required
+        requiredTemplates:
+          - path: deploymentDashboard.yaml
+          - path: deploymentMetrics.yaml
+          - path: cm-lookupCR.yaml

--- a/pkg/compare/testdata/LookupCRs/reference/metadata.yaml
+++ b/pkg/compare/testdata/LookupCRs/reference/metadata.yaml
@@ -1,0 +1,9 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: Dashboard
+        type: Required
+        requiredTemplates:
+          - path: deploymentDashboard.yaml
+          - path: deploymentMetrics.yaml
+          - path: cm-lookupCRs.yaml

--- a/pkg/compare/testdata/LookupCRs/resources/cm.yaml
+++ b/pkg/compare/testdata/LookupCRs/resources/cm.yaml
@@ -1,0 +1,10 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard
+data:
+  dashboard: kubernetes-dashboard
+  metrics: dashboard-metrics-scraper

--- a/pkg/compare/testdata/LookupCRs/resources/deploymentDashboard.yaml
+++ b/pkg/compare/testdata/LookupCRs/resources/deploymentDashboard.yaml
@@ -1,0 +1,66 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        k8s-app: kubernetes-dashboard
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubernetes-dashboard
+          image: kubernetesui/dashboard:v2.7.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+          args:
+            - --auto-generate-certificates
+            - --namespace=kubernetes-dashboard
+            # Uncomment the following line to manually specify Kubernetes API server Host
+            # If not specified, Dashboard will attempt to auto discover the API server and connect
+            # to it. Uncomment only if the default does not work.
+            # - --apiserver-host=http://my-address:port
+          volumeMounts:
+            - name: kubernetes-dashboard-certs
+              mountPath: /certs
+              # Create on-disk volume to store exec logs
+            - mountPath: /tmp
+              name: tmp-volume
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /
+              port: 8443
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
+      volumes:
+        - name: kubernetes-dashboard-certs
+          secret:
+            secretName: kubernetes-dashboard-certs
+        - name: tmp-volume
+          emptyDir: { }
+      serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "kubernetes.io/os": linux
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule

--- a/pkg/compare/testdata/LookupCRs/resources/deploymentMetrics.yaml
+++ b/pkg/compare/testdata/LookupCRs/resources/deploymentMetrics.yaml
@@ -1,0 +1,52 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper
+  namespace: kubernetes-dashboard
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: dashboard-metrics-scraper
+  template:
+    metadata:
+      labels:
+        k8s-app: dashboard-metrics-scraper
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: dashboard-metrics-scraper
+          image: kubernetesui/metrics-scraper:v1.0.8
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /
+              port: 8000
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-volume
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
+      serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "kubernetes.io/os": linux
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      volumes:
+        - name: tmp-volume
+          emptyDir: { }

--- a/pkg/compare/testdata/NoDiffs/localwithVebosityFlagout.golden
+++ b/pkg/compare/testdata/NoDiffs/localwithVebosityFlagout.golden
@@ -1,5 +1,9 @@
+Pre-processing template deploymentDashboard.yaml with empty data
+Pre-processing template deploymentMetrics.yaml with empty data
+Executing template deploymentMetrics.yaml
 Found 1 matches for apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
  - deploymentMetrics.yaml - Diff score: 0
+Executing template deploymentDashboard.yaml
 Found 1 matches for apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
  - deploymentDashboard.yaml - Diff score: 0
 **********************************

--- a/pkg/compare/testdata/SomeDiffs/localwithVebosityFlagout.golden
+++ b/pkg/compare/testdata/SomeDiffs/localwithVebosityFlagout.golden
@@ -1,5 +1,9 @@
+Pre-processing template deploymentDashboard.yaml with empty data
+Pre-processing template deploymentMetrics.yaml with empty data
+Executing template deploymentMetrics.yaml
 Found 1 matches for apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper
  - deploymentMetrics.yaml - Diff score: 5
+Executing template deploymentDashboard.yaml
 Found 1 matches for apps/v1_Deployment_kubernetes-dashboard_kubernetes-dashboard
  - deploymentDashboard.yaml - Diff score: 0
 **********************************

--- a/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localVerboseout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameKindNamespace/localVerboseout.golden
@@ -1,4 +1,8 @@
+Pre-processing template apps.v1.DaemonSet.kube-system.kindnet.yaml with empty data
+Pre-processing template apps.v1.DaemonSet.kube-system.kindnet2.yaml with empty data
 More than one template with same apiVersion, metadata_namespace, kind. By Default for each Cluster CR that is correlated to one of these templates the template with the least number of diffs will be used. To use a different template for a specific CR specify it in the diff-config (-c flag) Template names are: apps.v1.DaemonSet.kube-system.kindnet.yaml, apps.v1.DaemonSet.kube-system.kindnet2.yaml
+Executing template apps.v1.DaemonSet.kube-system.kindnet.yaml
+Executing template apps.v1.DaemonSet.kube-system.kindnet2.yaml
 Found 2 matches for apps/v1_DaemonSet_SomeNS_Name
  - apps.v1.DaemonSet.kube-system.kindnet.yaml - Diff score: 13
  - apps.v1.DaemonSet.kube-system.kindnet2.yaml - Diff score: 14

--- a/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localVerboseout.golden
+++ b/pkg/compare/testdata/TwoTemplatesWithSameapiVersionKindNameNamespace/localVerboseout.golden
@@ -1,4 +1,8 @@
+Pre-processing template apps.v1.DaemonSet.kube-system.kindnet.yaml with empty data
+Pre-processing template apps.v1.DaemonSet.kube-system.kindnet.yaml with empty data
 More than one template with same apiVersion, metadata_name, metadata_namespace, kind. By Default for each Cluster CR that is correlated to one of these templates the template with the least number of diffs will be used. To use a different template for a specific CR specify it in the diff-config (-c flag) Template names are: apps.v1.DaemonSet.kube-system.kindnet.yaml, apps.v1.DaemonSet.kube-system.kindnet.yaml
+Executing template apps.v1.DaemonSet.kube-system.kindnet.yaml
+Executing template apps.v1.DaemonSet.kube-system.kindnet.yaml
 Found 2 matches for apps/v1_DaemonSet_SomeNS_Name
  - apps.v1.DaemonSet.kube-system.kindnet.yaml - Diff score: 0
  - apps.v1.DaemonSet.kube-system.kindnet.yaml - Diff score: 0


### PR DESCRIPTION
- **Cleanup verbose logging by using klog.V(1) where possible**
- **Split main resource fetch and process into 2 steps**
- **Introduce 'lookupCRs' 'lookupCR' template functions**
- **helm-convert: Minor refactor and cleanup**
- **Add capability to override lookup functions in helm-convert tool**
