### PR TITLE
OCPBUGS-44249: Introduce 'doNotMatch' template function

### DIFF
--- a/docs/reference-config-guide-v2.md
+++ b/docs/reference-config-guide-v2.md
@@ -221,6 +221,27 @@ Returns the matching object if there is exactly one.  The `$apiVersion` and
 have the value `*` to match any namespace or name.  If multiple objects are
 matched, this returns `nil`.
 
+#### doNotMatch
+
+Allows a template to return an error which will force the correlation engine to
+never match this template with the CR under consideration, even if it would
+otherwise have done so.
+
+Usage:
+
+```yaml
+{{- if eq .metadata.annotations.nomeasure "true" }}
+  {{- doNotMatch "This template may not match nomeasure annotations" }}
+{{- end }}
+```
+
+The reason given as the argument is used for logging under `--verbose` output.
+
+Additionally, if a CR matches NO templates, and the reason is exclusively a set
+of these `doNotMatch` exceptions, that CRs failure to match is not counted as a
+comparison failure - The CR is assumed to be intentionally unchecked. This can
+be useful for nameless templates which would otherwise match too many CRs.
+
 ## Per-template configuration
 
 ### Pre-merging

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -665,6 +665,16 @@ func TestCompareRun(t *testing.T) {
 		defaultTest("LookupCRs").
 			withSubTestSuffix("LookupCR").
 			withMetadataFile("metadata-lookupCR.yaml"),
+
+		defaultTest("Do Not Match"),
+		defaultTest("Do Not Match").
+			withSubTestSuffix("No matches").
+			withMetadataFile("metadata-nomatch.yaml").
+			withChecks(defaultChecks.withPrefixedSuffix("NoMatch")),
+		defaultTest("Do Not Match").
+			withSubTestSuffix("Filter unnamed template matches").
+			withMetadataFile("metadata-filter.yaml").
+			withChecks(defaultChecks.withPrefixedSuffix("Filter")),
 	}
 
 	tf := cmdtesting.NewTestFactory()

--- a/pkg/compare/funcmap.go
+++ b/pkg/compare/funcmap.go
@@ -5,6 +5,7 @@ package compare
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -46,6 +47,7 @@ func FuncMap() template.FuncMap {
 		"fromJsonArray": fromJSONArray,
 		"lookupCRs":     lookupCRs,
 		"lookupCR":      lookupCR,
+		"doNotMatch":    doNotMatch,
 	}
 
 	for k, v := range extra {
@@ -200,4 +202,16 @@ func lookupCR(apiVersion, kind, namespace, name string) map[string]any {
 		return nil
 	}
 	return all[0]
+}
+
+type DoNotMatch struct {
+	Reason string
+}
+
+func (e DoNotMatch) Error() string {
+	return fmt.Sprintf("Do not match: %s", e.Reason)
+}
+
+func doNotMatch(reason string) (string, error) {
+	return "", &DoNotMatch{Reason: reason}
 }

--- a/pkg/compare/testdata/DoNotMatch/localFilterout.golden
+++ b/pkg/compare/testdata/DoNotMatch/localFilterout.golden
@@ -1,0 +1,6 @@
+Summary
+CRs with diffs: 0/1
+No validation issues with the cluster
+No CRs are unmatched to reference CRs
+Metadata Hash: $METADATA_HASH$
+No patched CRs

--- a/pkg/compare/testdata/DoNotMatch/localNoMatcherr.golden
+++ b/pkg/compare/testdata/DoNotMatch/localNoMatcherr.golden
@@ -1,0 +1,2 @@
+
+error code:1

--- a/pkg/compare/testdata/DoNotMatch/localNoMatchout.golden
+++ b/pkg/compare/testdata/DoNotMatch/localNoMatchout.golden
@@ -1,0 +1,10 @@
+Summary
+CRs with diffs: 0/0
+CRs in reference missing from the cluster: 1
+ExamplePart:
+  Test:
+    One of the following is required:
+    - nevermatch.yaml
+No CRs are unmatched to reference CRs
+Metadata Hash: $METADATA_HASH$
+No patched CRs

--- a/pkg/compare/testdata/DoNotMatch/localout.golden
+++ b/pkg/compare/testdata/DoNotMatch/localout.golden
@@ -1,0 +1,7 @@
+The reference contains overlapping object definitions which may result in unexpected correlation results. Re-run with '--verbose' output enabled to view a detailed description of the issues
+Summary
+CRs with diffs: 0/1
+No validation issues with the cluster
+No CRs are unmatched to reference CRs
+Metadata Hash: $METADATA_HASH$
+No patched CRs

--- a/pkg/compare/testdata/DoNotMatch/reference/d1-anyname.yaml
+++ b/pkg/compare/testdata/DoNotMatch/reference/d1-anyname.yaml
@@ -1,0 +1,69 @@
+{{- if eq .metadata.annotations.test "exclude" }}
+  {{- doNotMatch "Test reason" }}
+{{- end -}}
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: {{ .metadata.name }}
+  namespace: kubernetes-dashboard
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        k8s-app: kubernetes-dashboard
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubernetes-dashboard
+          image: kubernetesui/dashboard:v2.7.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+          args:
+            - --auto-generate-certificates
+            - --namespace=kubernetes-dashboard
+            # Uncomment the following line to manually specify Kubernetes API server Host
+            # If not specified, Dashboard will attempt to auto discover the API server and connect
+            # to it. Uncomment only if the default does not work.
+            # - --apiserver-host=http://my-address:port
+          volumeMounts:
+            - name: kubernetes-dashboard-certs
+              mountPath: /certs
+              # Create on-disk volume to store exec logs
+            - mountPath: /tmp
+              name: tmp-volume
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /
+              port: 8443
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
+      volumes:
+        - name: kubernetes-dashboard-certs
+          secret:
+            secretName: kubernetes-dashboard-certs
+        - name: tmp-volume
+          emptyDir: { }
+      serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "kubernetes.io/os": linux
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule

--- a/pkg/compare/testdata/DoNotMatch/reference/match.yaml
+++ b/pkg/compare/testdata/DoNotMatch/reference/match.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard

--- a/pkg/compare/testdata/DoNotMatch/reference/metadata-filter.yaml
+++ b/pkg/compare/testdata/DoNotMatch/reference/metadata-filter.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: Test
+        allOf:
+          - path: d1-anyname.yaml

--- a/pkg/compare/testdata/DoNotMatch/reference/metadata-nomatch.yaml
+++ b/pkg/compare/testdata/DoNotMatch/reference/metadata-nomatch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: Test
+        oneOf:
+          - path: nevermatch.yaml

--- a/pkg/compare/testdata/DoNotMatch/reference/metadata.yaml
+++ b/pkg/compare/testdata/DoNotMatch/reference/metadata.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+parts:
+  - name: ExamplePart
+    components:
+      - name: Test
+        oneOf:
+          - path: nevermatch.yaml
+          - path: match.yaml

--- a/pkg/compare/testdata/DoNotMatch/reference/nevermatch.yaml
+++ b/pkg/compare/testdata/DoNotMatch/reference/nevermatch.yaml
@@ -1,0 +1,10 @@
+{{- if .kind }}
+{{- doNotMatch "Test reason" }}
+{{- end -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard

--- a/pkg/compare/testdata/DoNotMatch/resources/cm.yaml
+++ b/pkg/compare/testdata/DoNotMatch/resources/cm.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-settings
+  namespace: kubernetes-dashboard

--- a/pkg/compare/testdata/DoNotMatch/resources/d1.yaml
+++ b/pkg/compare/testdata/DoNotMatch/resources/d1.yaml
@@ -1,0 +1,66 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        k8s-app: kubernetes-dashboard
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubernetes-dashboard
+          image: kubernetesui/dashboard:v2.7.0
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+          args:
+            - --auto-generate-certificates
+            - --namespace=kubernetes-dashboard
+            # Uncomment the following line to manually specify Kubernetes API server Host
+            # If not specified, Dashboard will attempt to auto discover the API server and connect
+            # to it. Uncomment only if the default does not work.
+            # - --apiserver-host=http://my-address:port
+          volumeMounts:
+            - name: kubernetes-dashboard-certs
+              mountPath: /certs
+              # Create on-disk volume to store exec logs
+            - mountPath: /tmp
+              name: tmp-volume
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /
+              port: 8443
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
+      volumes:
+        - name: kubernetes-dashboard-certs
+          secret:
+            secretName: kubernetes-dashboard-certs
+        - name: tmp-volume
+          emptyDir: { }
+      serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "kubernetes.io/os": linux
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule

--- a/pkg/compare/testdata/DoNotMatch/resources/d2.yaml
+++ b/pkg/compare/testdata/DoNotMatch/resources/d2.yaml
@@ -1,0 +1,54 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  labels:
+    k8s-app: dashboard-metrics-scraper
+  name: dashboard-metrics-scraper
+  namespace: kubernetes-dashboard
+  annotations:
+    test: exclude
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: dashboard-metrics-scraper-diff
+  template:
+    metadata:
+      labels:
+        k8s-app: dashboard-metrics-scraper
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: dashboard-metrics-scraper
+          image: kubernetesui/metrics-scraper:v1.0.8
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /
+              port: 8000
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-volume
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
+      serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "kubernetes.io/os": linux
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      volumes:
+        - name: tmp-volume
+          emptyDir: { }


### PR DESCRIPTION
This allows templates to actively opt-out of matching certain CRs.

For example, this can be useful for nameless templates which would
otherwise match too many CRs. if there is some other criteria for
inclusion/exclusion, the template may check and call the `doNotMatch`
function if it should not be allowed to match the current CR.

See `d1-anyname.yaml` for a contrived but useful example.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>
