### PR TITLE
Group dependabot updates by package origin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,20 @@ updates:
       - "ok-to-test"
       - "dependencies"
     open-pull-requests-limit: 5
+    groups:
+      k8s:
+        patterns: ["k8s.io/*", "sigs.k8s.io/*"]
+        update-types: ["major", "minor", "patch"]
+      openshift:
+        patterns: ["github.com/openshift/*"]
+        update-types: ["major", "minor", "patch"]
+      other-go-modules:
+        patterns: ["*"]
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+          - "github.com/openshift/*"
+        update-types: ["major", "minor", "patch"]
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
## Summary
- Add `k8s` group to consolidate `k8s.io/*` and `sigs.k8s.io/*` dependency updates
- Add `openshift` group to consolidate `github.com/openshift/*` dependency updates  
- Add `other-go-modules` group with exclude patterns for remaining dependencies

This reduces noise from individual dependency update PRs by grouping related Kubernetes and OpenShift library updates together.

## Related PRs
- https://github.com/openshift/assisted-service/pull/8718
- https://github.com/openshift/backplane-cli/pull/1111
- https://github.com/openshift/cluster-openshift-apiserver-operator/pull/648
- https://github.com/openshift/containernetworking-plugins/pull/74
- https://github.com/openshift/ingress-node-firewall/pull/276
- https://github.com/openshift/oc-mirror/pull/1285
- https://github.com/openshift/pf-status-relay-operator/pull/69

## Test plan
- [ ] Verify YAML syntax is valid
- [ ] Verify dependabot can parse the configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)