### PR TITLE
Handle swallowed errors across pkg/compare

### DIFF
--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -784,7 +784,10 @@ func (o *Options) Run() error {
 	clusterCRs := make([]*unstructured.Unstructured, 0)
 	uniqueIDs := make(map[string]bool)
 	for _, info := range infos {
-		clusterCRMapping, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(info.Object)
+		clusterCRMapping, err := runtime.DefaultUnstructuredConverter.ToUnstructured(info.Object)
+		if err != nil {
+			klog.Warningf("Failed to convert resource to unstructured: %v", err)
+		}
 		obj := &unstructured.Unstructured{Object: clusterCRMapping}
 		id := apiKindNamespaceName(obj)
 		if _, exists := uniqueIDs[id]; !exists {

--- a/pkg/compare/correlator.go
+++ b/pkg/compare/correlator.go
@@ -350,9 +350,13 @@ func NewOwnerReferenceCorrelator[T CorrelationEntry](templates []T, clusterCRs [
 				continue
 			}
 
-			apiVersion, _, _ := unstructured.NestedString(ownerRef, "apiVersion")
-			kind, _, _ := unstructured.NestedString(ownerRef, "kind")
-			name, _, _ := unstructured.NestedString(ownerRef, "name")
+			apiVersion, _, err1 := unstructured.NestedString(ownerRef, "apiVersion")
+			kind, _, err2 := unstructured.NestedString(ownerRef, "kind")
+			name, _, err3 := unstructured.NestedString(ownerRef, "name")
+			if err1 != nil || err2 != nil || err3 != nil {
+				klog.V(1).Infof("Skipping ownerReference with non-string fields: %v %v %v", err1, err2, err3)
+				continue
+			}
 
 			if apiVersion == "" || kind == "" || name == "" {
 				continue
@@ -436,9 +440,13 @@ func NewSubjectsCorrelator[T CorrelationEntry](templates []T, clusterCRs []*unst
 
 			// Extract subject information
 			// Note: subjects use "kind" not "apiVersion"
-			subjKind, _, _ := unstructured.NestedString(subject, "kind")
-			subjName, _, _ := unstructured.NestedString(subject, "name")
-			subjNamespace, _, _ := unstructured.NestedString(subject, "namespace")
+			subjKind, _, err1 := unstructured.NestedString(subject, "kind")
+			subjName, _, err2 := unstructured.NestedString(subject, "name")
+			subjNamespace, _, err3 := unstructured.NestedString(subject, "namespace")
+			if err1 != nil || err2 != nil || err3 != nil {
+				klog.V(1).Infof("Skipping subject with non-string fields: %v %v %v", err1, err2, err3)
+				continue
+			}
 
 			if subjKind == "" || subjName == "" {
 				continue

--- a/pkg/compare/funcmap.go
+++ b/pkg/compare/funcmap.go
@@ -138,7 +138,7 @@ func DisplayFuncmap(w io.Writer) {
 func toYAML(v any) string {
 	data, err := yaml.Marshal(v)
 	if err != nil {
-		// Swallow errors inside of a template.
+		klog.Warningf("Failed to marshal value to YAML in template: %v", err)
 		return ""
 	}
 	return strings.TrimSuffix(string(data), "\n")
@@ -195,7 +195,7 @@ func toTOML(v any) string {
 func toJSON(v any) string {
 	data, err := json.Marshal(v)
 	if err != nil {
-		// Swallow errors inside of a template.
+		klog.Warningf("Failed to marshal value to JSON in template: %v", err)
 		return ""
 	}
 	return string(data)

--- a/pkg/compare/output.go
+++ b/pkg/compare/output.go
@@ -37,6 +37,20 @@ type DiffSum struct {
 	Description        string   `json:"description,omitempty"`
 }
 
+func renderTemplate(name, templateStr string, funcs template.FuncMap, data any, fallback string) string {
+	tmpl, err := template.New(name).Funcs(funcs).Parse(templateStr)
+	if err != nil {
+		klog.Warningf("Failed to parse %s template: %v", name, err)
+		return fallback
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		klog.Warningf("Failed to execute %s template: %v", name, err)
+		return fallback
+	}
+	return strings.TrimSpace(buf.String())
+}
+
 func (s DiffSum) String() string {
 	t := `
 Cluster CR: {{ .CRName }}
@@ -58,10 +72,8 @@ Patch Reasons:
 {{- end }}
 {{- end }}
 `
-	var buf bytes.Buffer
-	tmpl, _ := template.New("DiffSummary").Funcs(sprig.TxtFuncMap()).Parse(t)
-	_ = tmpl.Execute(&buf, s)
-	return strings.TrimSpace(buf.String())
+	fallback := fmt.Sprintf("Cluster CR: %s\nReference File: %s\nDiff Output: %s", s.CRName, s.CorrelatedTemplate, s.DiffOutput)
+	return renderTemplate("DiffSummary", t, sprig.TxtFuncMap(), s, fallback)
 }
 
 func (s DiffSum) HasDiff() bool {
@@ -158,10 +170,10 @@ Cluster CRs with patches applied: {{ .PatchedCRs }}
 No patched CRs
 {{- end }}
 `
-	var buf bytes.Buffer
-	tmpl, _ := template.New("Summary").Funcs(sprig.TxtFuncMap()).Funcs(template.FuncMap{"toYaml": toYAML}).Parse(t)
-	_ = tmpl.Execute(&buf, s)
-	return strings.TrimSpace(buf.String())
+	funcs := sprig.TxtFuncMap()
+	funcs["toYaml"] = toYAML
+	fallback := fmt.Sprintf("Summary\nCRs with diffs: %d/%d", s.NumDiffCRs, s.TotalCRs)
+	return renderTemplate("Summary", t, funcs, s, fallback)
 }
 
 // Output Contains the complete output of the command

--- a/pkg/compare/referenceV2.go
+++ b/pkg/compare/referenceV2.go
@@ -349,7 +349,11 @@ func getFieldNameFromStructTag(c *ComponentV2, s ComponentV2Group) string {
 	// Because of embedding we can use the type as the field name to lookup the struct tags
 	x := strings.Split(fmt.Sprintf("%T", s), ".")
 	y := x[len(x)-1]
-	field, _ := reflect.TypeOf(c).Elem().FieldByName(y)
+	field, ok := reflect.TypeOf(c).Elem().FieldByName(y)
+	if !ok {
+		klog.Warningf("Failed to find struct field %q in ComponentV2", y)
+		return y
+	}
 	return strings.Split(field.Tag.Get("json"), ",")[0]
 }
 

--- a/pkg/compare/regexInlineDiff.go
+++ b/pkg/compare/regexInlineDiff.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -55,7 +57,11 @@ func (c *capturedValueIndices) getTopLevelIndices() []capturedGroupIndex {
 }
 
 func (id RegexInlineDiff) Diff(regex, crValue string, sharedCapturedValues CapturedValues) (string, CapturedValues) {
-	re, _ := regexp.Compile(regex)
+	re, err := regexp.Compile(regex)
+	if err != nil {
+		klog.V(1).Infof("Failed to compile regex %q in inline diff: %v", regex, err)
+		return regex, sharedCapturedValues
+	}
 	matchedIndices := re.FindStringSubmatchIndex(crValue)
 	if matchedIndices == nil {
 		return regex, sharedCapturedValues


### PR DESCRIPTION
## Summary
- Handle ~15 previously swallowed errors across `pkg/compare` — template parse/execute failures, marshal errors, nil-panic on invalid regex, conversion errors, and reflection field lookups now log warnings or return graceful fallbacks instead of silently discarding errors
- Extract `renderTemplate` helper in `output.go` to deduplicate template fallback logic

## Files changed
- **output.go**: Check template parse/execute errors with fallback rendering via new `renderTemplate` helper
- **funcmap.go**: Log marshal errors in `toYAML`/`toJSON` template functions
- **regexInlineDiff.go**: Check `regexp.Compile` to prevent nil-panic on invalid regex
- **compare.go**: Log `ToUnstructured` conversion errors
- **correlator.go**: Check `NestedString` errors in ownerRef/subjects indexing
- **referenceV2.go**: Check `reflect.FieldByName` result

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet ./pkg/...` passes
- [ ] `make test-all` — no new test failures introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling and logging across comparison operations. The system now gracefully handles edge cases such as failed object conversions, field extraction issues, template rendering errors, and regex compilation failures. Operations continue with fallback mechanisms while emitting diagnostic warnings, enhancing observability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->