### PR TITLE
CNF-23446: Replace magic strings with named constants across pkg/compare

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
 	helm.sh/helm/v3 v3.18.4
+	k8s.io/api v0.34.0
 	k8s.io/apimachinery v0.34.0
 	k8s.io/cli-runtime v0.34.0
 	k8s.io/client-go v0.34.0
@@ -91,7 +92,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.34.0 // indirect
 	k8s.io/apiextensions-apiserver v0.33.2 // indirect
 	k8s.io/component-base v0.34.0 // indirect
 	k8s.io/component-helpers v0.34.0 // indirect

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -103,9 +103,14 @@ const (
 	skipInvalidResources  = "Skipping %s Input contains additional files from supported file extensions" +
 		" (json/yaml) that do not contain a valid resource, error: %s.\n In case this file is " +
 		"expected to be a valid resource modify it accordingly. "
-	DiffsFoundMsg           = "there are differences between the cluster CRs and the reference CRs"
-	noTemplateForGeneration = "Requested user override generation but no entires for which template to generate overrides for"
-	noReason                = "Reason required when generating overrides"
+	DiffsFoundMsg                   = "there are differences between the cluster CRs and the reference CRs"
+	errMissingKind                  = "Object 'Kind' is missing"
+	errParsing                      = "error parsing"
+	diffLabelMerged                 = "MERGED"
+	diffLabelLive                   = "LIVE"
+	warningTypeInferredNotValidated = "InferredResourcesNotValidated"
+	noTemplateForGeneration         = "Requested user override generation but no entires for which template to generate overrides for"
+	noReason                        = "Reason required when generating overrides"
 )
 
 const (
@@ -646,7 +651,7 @@ func diffAgainstTemplate(temp ReferenceTemplate, clusterCR *unstructured.Unstruc
 		return res, fmt.Errorf("template injection failed: %w", err)
 	}
 
-	differ, err := diff.NewDiffer("MERGED", "LIVE")
+	differ, err := diff.NewDiffer(diffLabelMerged, diffLabelLive)
 	diffOutput := new(bytes.Buffer)
 
 	res.output = diffOutput
@@ -708,7 +713,7 @@ func buildWarnings(sum *Summary) []Warning {
 
 	if len(sum.MatchedByReferenceOnly) > 0 {
 		warnings = append(warnings, Warning{
-			Type:      "InferredResourcesNotValidated",
+			Type:      warningTypeInferredNotValidated,
 			Message:   "Resource(s) found via ownerReferences or RBAC subjects but contents not validated",
 			Resources: sum.MatchedByReferenceOnly,
 		})
@@ -763,11 +768,11 @@ func (o *Options) Run() error {
 		return fmt.Errorf("failed to collect resources: %w", err)
 	}
 	ignoreErrors := func(err error) bool {
-		if strings.Contains(err.Error(), "Object 'Kind' is missing") {
+		if strings.Contains(err.Error(), errMissingKind) {
 			klog.Warningf(skipInvalidResources, extractPath(err.Error(), 3), "'Kind' is missing")
 			return true
 		}
-		if strings.Contains(err.Error(), "error parsing") {
+		if strings.Contains(err.Error(), errParsing) {
 			// TODO: Fix this error message truncation
 			klog.Warningf(skipInvalidResources, extractPath(err.Error(), 2), err.Error()[strings.LastIndex(err.Error(), ":"):])
 			return true

--- a/pkg/compare/container.go
+++ b/pkg/compare/container.go
@@ -16,9 +16,11 @@ type engine struct {
 	tempDir      string
 }
 
+const containerScheme = "container://"
+
 // isContainer reports whether the given path is a reference to a file in a container by verifying if it starts with "container://".
 func isContainer(path string) bool {
-	return strings.HasPrefix(path, "container://")
+	return strings.HasPrefix(path, containerScheme)
 }
 
 type parsedPath struct {
@@ -29,7 +31,7 @@ type parsedPath struct {
 // parsePath returns the image and referencePath (path to the directory for metadata.yaml), given a path
 // of the form container://<IMAGE>:<TAG>:/path_to_metadata.yaml
 func parsePath(path string) (parsedPath, error) {
-	path = strings.TrimPrefix(path, "container://")
+	path = strings.TrimPrefix(path, containerScheme)
 
 	// Split on ':', removing empty strings from slice. Removes errant colons from string,
 	// so container://<IMAGE>:::<TAG>::::::/path/to/metadata.yaml will still work, but

--- a/pkg/compare/correlator.go
+++ b/pkg/compare/correlator.go
@@ -10,11 +10,18 @@ import (
 	"strings"
 	"sync"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/klog/v2"
 )
 
 var FieldSeparator = "_"
+
+const (
+	kindClusterRoleBinding = "ClusterRoleBinding"
+	kindRoleBinding        = "RoleBinding"
+	coreAPIVersion         = "v1"
+)
 
 // Correlator provides an abstraction that allow the usage of different Resource correlation logics
 // in the kubectl cluster-compare. The correlation process Matches for each Resource a template.
@@ -423,7 +430,7 @@ func NewSubjectsCorrelator[T CorrelationEntry](templates []T, clusterCRs []*unst
 	for _, clusterCR := range clusterCRs {
 		// Only check RBAC resources (ClusterRoleBinding, RoleBinding)
 		kind := clusterCR.GetKind()
-		if kind != "ClusterRoleBinding" && kind != "RoleBinding" {
+		if kind != kindClusterRoleBinding && kind != kindRoleBinding {
 			continue
 		}
 
@@ -456,9 +463,9 @@ func NewSubjectsCorrelator[T CorrelationEntry](templates []T, clusterCRs []*unst
 			// ServiceAccount subjects use "v1" as apiVersion
 			var apiVersion string
 			switch subjKind {
-			case "ServiceAccount":
-				apiVersion = "v1"
-			case "User", "Group":
+			case rbacv1.ServiceAccountKind:
+				apiVersion = coreAPIVersion
+			case rbacv1.UserKind, rbacv1.GroupKind:
 				// Users and Groups don't have apiVersions in the same way
 				continue
 			default:

--- a/pkg/compare/httpfs.go
+++ b/pkg/compare/httpfs.go
@@ -12,11 +12,15 @@ import (
 	"time"
 )
 
-const defaultHttpGetAttempts = 5
+const (
+	defaultHttpGetAttempts = 5
+	httpScheme             = "http://"
+	httpsScheme            = "https://"
+)
 
 // isURL checks if the given path is a URL by verifying if it starts with "http://" or "https://".
 func isURL(path string) bool {
-	return strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://")
+	return strings.HasPrefix(path, httpScheme) || strings.HasPrefix(path, httpsScheme)
 }
 
 // HTTPFS represents a file system that retrieves files from a http server by returning the http response body,

--- a/pkg/compare/output.go
+++ b/pkg/compare/output.go
@@ -20,6 +20,12 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	junitFailureTypeDifference = "Difference"
+	junitFailureTypeValidation = "Validation Issue"
+	junitFailureTypeUnmatched  = "Unmatched CR"
+)
+
 // Warning represents a warning message in the output
 type Warning struct {
 	Type      string   `json:"type"`
@@ -274,7 +280,7 @@ func (o Output) junitDiffSuite() junit.TestSuite {
 
 		if diff.DiffOutput != "" {
 			testCase.Failure = &junit.Failure{
-				Type:     "Difference",
+				Type:     junitFailureTypeDifference,
 				Message:  fmt.Sprintf("Differences found in CR: %s, Compared To Reference CR: %s", diff.CRName, diff.CorrelatedTemplate),
 				Contents: diff.DiffOutput,
 			}
@@ -304,7 +310,7 @@ func (o Output) junitValidationIssueSuite() junit.TestSuite {
 				Name:      "Reference validation failure",
 				Classname: fmt.Sprintf("Part:%s Component: %s", partName, componentName),
 				Failure: &junit.Failure{
-					Type:    "Validation Issue",
+					Type:    junitFailureTypeValidation,
 					Message: fmt.Sprintf("%s: %s", validationIssue.Msg, strings.Join(validationIssue.CRs, ",")),
 				},
 			})
@@ -336,7 +342,7 @@ func (o Output) junitUnmatchedCRsSuite() junit.TestSuite {
 		suite.AddCase(junit.TestCase{
 			Name: cr,
 			Failure: &junit.Failure{
-				Type:    "Unmatched CR",
+				Type:    junitFailureTypeUnmatched,
 				Message: fmt.Sprintf("Cluster resource '%s' is unmatched.", cr),
 			},
 		})

--- a/pkg/compare/parsing.go
+++ b/pkg/compare/parsing.go
@@ -66,7 +66,7 @@ func GetReference(fsys fs.FS, referenceFileName string) (Reference, error) {
 	versionAny, ok := verCheck["apiVersion"]
 	var version string
 	if !ok {
-		version = "v1"
+		version = ReferenceVersionV1
 	} else {
 		version = strings.TrimSpace(fmt.Sprint(versionAny))
 	}

--- a/pkg/compare/referenceV2.go
+++ b/pkg/compare/referenceV2.go
@@ -367,6 +367,7 @@ func componentV2GroupUnmarshalJSON(s ComponentV2Group, b []byte) (err error) {
 const (
 	MissingCRsMsg      = "Missing CRs"
 	MatchedMoreThanOne = "Should only match one but matched"
+	oneOfRequired      = "One of the following is required"
 )
 
 type OneOf struct {
@@ -389,7 +390,7 @@ func (g *OneOf) getMissingCRs(matchedTemplates map[string]int) (ValidationIssue,
 	}
 	if len(matched) == 0 {
 		return ValidationIssue{
-			Msg: "One of the following is required",
+			Msg: oneOfRequired,
 			CRs: notMatched,
 		}, 1
 	}


### PR DESCRIPTION
## Summary

- Extract inline string literals used in comparisons, error detection, and identification into named constants across 7 files in `pkg/compare/`
- Use upstream `rbacv1.ServiceAccountKind`, `rbacv1.UserKind`, `rbacv1.GroupKind` constants from `k8s.io/api/rbac/v1` instead of hand-rolled duplicates
- Reuse existing `ReferenceVersionV1` constant in `parsing.go` instead of duplicating the `"v1"` literal

Jira: https://redhat.atlassian.net/browse/CNF-23446

## Test plan

- [x] `go build ./pkg/compare/...` passes
- [x] `go vet ./pkg/compare/...` clean
- [x] All tests pass (2 pre-existing failures on main confirmed unrelated)
- [x] No golden file changes — pure refactor with no behavior change


## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicated string literals into shared constants across components (schemes, labels, messaging, RBAC kinds and parsing defaults) for improved consistency and maintainability.
  * No functional or user-facing behavior changed; public APIs and outputs remain the same.
