### PR TITLE
junit: switch time to zero instead of timestamp

### DIFF
--- a/pkg/compare/testdata/JunitOutput/localout.golden
+++ b/pkg/compare/testdata/JunitOutput/localout.golden
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="Comparison results of known valid reference configuration and a set of specific cluster CRs" tests="3" failures="2" errors="0" skipped="0" time="TIME">
-	<testsuite tests="1" failures="1" skipped="0" time="TIME" name="Detected Differences Between Cluster CRs and Expected CRs" timestamp="TIME">
+<testsuites name="Comparison results of known valid reference configuration and a set of specific cluster CRs" tests="3" failures="2" errors="0" skipped="0" time="0">
+	<testsuite tests="1" failures="1" skipped="0" time="0" name="Detected Differences Between Cluster CRs and Expected CRs" timestamp="TIME">
 		<properties>
 			<property name="MetadataHash" value="aa4c94f1307788e1da81f57718a9f1364d35d4ff6099fc633724bcf9d051a094"></property>
 			<property name="TotalCRs" value="1"></property>
 		</properties>
-		<testcase classname="Matching Reference CR: deploymentMetrics.yaml" name="CR: apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper" time="">
+		<testcase classname="Matching Reference CR: deploymentMetrics.yaml" name="CR: apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper" time="0">
 			<properties></properties>
 			<failure message="Differences found in CR: apps/v1_Deployment_kubernetes-dashboard_dashboard-metrics-scraper, Compared To Reference CR: deploymentMetrics.yaml" type="Difference">diff -u -N TEMP/apps-v1_deployment_kubernetes-dashboard_dashboard-metrics-scraper TEMP/apps-v1_deployment_kubernetes-dashboard_dashboard-metrics-scraper&#xA;--- TEMP/apps-v1_deployment_kubernetes-dashboard_dashboard-metrics-scraper&#x9;DATE&#xA;+++ TEMP/apps-v1_deployment_kubernetes-dashboard_dashboard-metrics-scraper&#x9;DATE&#xA;@@ -10,7 +10,7 @@&#xA;   revisionHistoryLimit: 10&#xA;   selector:&#xA;     matchLabels:&#xA;-      k8s-app: dashboard-metrics-scraper&#xA;+      k8s-app: dashboard-metrics-scraper-diff&#xA;   template:&#xA;     metadata:&#xA;       labels:&#xA;</failure>
 		</testcase>
 	</testsuite>
-	<testsuite tests="1" failures="1" skipped="0" time="TIME" name="Reference validation" timestamp="TIME">
+	<testsuite tests="1" failures="1" skipped="0" time="0" name="Reference validation" timestamp="TIME">
 		<properties>
 			<property name="MetadataHash" value="aa4c94f1307788e1da81f57718a9f1364d35d4ff6099fc633724bcf9d051a094"></property>
 			<property name="TotalCRs" value="1"></property>
 		</properties>
-		<testcase classname="Part:ExamplePart Component: Dashboard" name="Reference validation failure" time="">
+		<testcase classname="Part:ExamplePart Component: Dashboard" name="Reference validation failure" time="0">
 			<properties></properties>
 			<failure message="Missing CRs: deploymentDashboard.yaml" type="Validation Issue"></failure>
 		</testcase>
 	</testsuite>
-	<testsuite tests="1" failures="0" skipped="0" time="TIME" name="Unmatched Cluster Resources" timestamp="TIME">
+	<testsuite tests="1" failures="0" skipped="0" time="0" name="Unmatched Cluster Resources" timestamp="TIME">
 		<properties>
 			<property name="MetadataHash" value="aa4c94f1307788e1da81f57718a9f1364d35d4ff6099fc633724bcf9d051a094"></property>
 			<property name="TotalCRs" value="1"></property>
 		</properties>
-		<testcase classname="" name="All Cluster CRs are matched to reference CRs " time="">
+		<testcase classname="" name="All Cluster CRs are matched to reference CRs " time="0">
 			<properties></properties>
 		</testcase>
 	</testsuite>

--- a/pkg/junit/junit.go
+++ b/pkg/junit/junit.go
@@ -7,6 +7,10 @@ import (
 	"time"
 )
 
+// zeroDuration is the time attribute value for testsuites, testsuite, and testcase elements.
+// JUnit expects elapsed seconds; kube-compare does not track per-test duration.
+const zeroDuration = "0"
+
 // TestSuites is a collection of JUnit test suites.
 type TestSuites struct {
 	XMLName  xml.Name `xml:"testsuites"`
@@ -22,7 +26,7 @@ type TestSuites struct {
 func NewTestSuites(name string) *TestSuites {
 	testSuites := TestSuites{
 		Name: name,
-		Time: time.Now().Format(time.RFC3339),
+		Time: zeroDuration,
 	}
 	return &testSuites
 }
@@ -54,6 +58,9 @@ type TestSuite struct {
 }
 
 func (id *TestSuite) AddCase(tcase TestCase) {
+	if tcase.Time == "" {
+		tcase.Time = zeroDuration
+	}
 	id.TestCases = append(id.TestCases, tcase)
 	id.Tests += 1
 	if tcase.Failure != nil {
@@ -98,11 +105,10 @@ type Failure struct {
 }
 
 func NewTestSuite(name string) TestSuite {
-	timestamp := time.Now().Format(time.RFC3339)
 	return TestSuite{
 		Name:      name,
-		Timestamp: timestamp,
-		Time:      timestamp,
+		Timestamp: time.Now().Format(time.RFC3339),
+		Time:      zeroDuration,
 	}
 }
 


### PR DESCRIPTION
The JUnit format expects the time attribute to represent the duration of a test, not the timestamp. The JUnit output from kube-compare already correctly adds the timestamp attribute as a timestamp, but then sets time to be the same. For tools which are stricter about the JUnit schema, this causes errors parsing the kube-compare output.

This commit switches to always setting `time="0"` in the `testsuites`, `testsuite`, and `testcase` tags. Since the duration would not be relevant, `"0"` is chosen as a default. Alternatively, the attribute could be removed since it is optional, but since it is already present, setting it to zero works as well.

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Test suite timestamps in JUnit XML reports now use RFC3339 standard formatting, with duration values consistently set to zero
* Test case timing is now properly initialized with zero-duration values when empty, ensuring consistent duration handling across all test reports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->