### PR TITLE
OCPBUGS-92049: Remove getHostByName from sprig FuncMap

### DIFF
--- a/pkg/compare/funcmap.go
+++ b/pkg/compare/funcmap.go
@@ -41,6 +41,7 @@ func FuncMap() template.FuncMap {
 	f := sprig.TxtFuncMap()
 	delete(f, "env")
 	delete(f, "expandenv")
+	delete(f, "getHostByName")
 
 	for key := range f {
 		FuncHelp[key] = SprigImportFlag

--- a/pkg/compare/output.go
+++ b/pkg/compare/output.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/Masterminds/sprig/v3"
 	"github.com/openshift/kube-compare/pkg/junit"
 	"github.com/samber/lo"
 
@@ -79,7 +78,7 @@ Patch Reasons:
 {{- end }}
 `
 	fallback := fmt.Sprintf("Cluster CR: %s\nReference File: %s\nDiff Output: %s", s.CRName, s.CorrelatedTemplate, s.DiffOutput)
-	return renderTemplate("DiffSummary", t, sprig.TxtFuncMap(), s, fallback)
+	return renderTemplate("DiffSummary", t, FuncMap(), s, fallback)
 }
 
 func (s DiffSum) HasDiff() bool {
@@ -176,8 +175,7 @@ Cluster CRs with patches applied: {{ .PatchedCRs }}
 No patched CRs
 {{- end }}
 `
-	funcs := sprig.TxtFuncMap()
-	funcs["toYaml"] = toYAML
+	funcs := FuncMap()
 	fallback := fmt.Sprintf("Summary\nCRs with diffs: %d/%d", s.NumDiffCRs, s.TotalCRs)
 	return renderTemplate("Summary", t, funcs, s, fallback)
 }


### PR DESCRIPTION
## Description

This PR fixes the `kc-cmp-001` security finding. 

`kube-compare` attempts to sandbox the template execution environment (for untrusted remote references) by stripping `env` and `expandenv` from the `sprig` function map. However, it accidentally leaves `getHostByName` available.

A malicious reference author could craft a template that reads a cluster Secret via `lookupCRs`, encodes it, and passes it to `getHostByName`. The tool would then perform a DNS lookup while rendering the template, covertly exfiltrating sensitive cluster data via DNS.

This change explicitly removes `getHostByName` from the funcmap to close this DNS egress channel.

## Testing
Tested with `make test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed access to an unsafe template helper from the standard template function set, preventing templates from using it via the built-in helper map.
  * Kept existing helper mappings and their help-text behavior the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->