### PR TITLE
Add Helm-compatible include template function

### DIFF
--- a/docs/reference-config-guide-v1.md
+++ b/docs/reference-config-guide-v1.md
@@ -84,7 +84,7 @@ inclusion/exclusion of content. The following types of user variation are expect
 
 GO templating allows use of custom and built in functions to allow complex use cases. In this version all Go built-in
 functions are supported along with the functions in the Sprig library. Also this version follows the Helm templating
-behavior and supports all custom functions that are used in helm (example: toYaml).
+behavior and supports several Helm-style helper functions (e.g. toYaml, toJson, fromYaml, fromJson, include).
 
 ```yaml
 apiVersion: v1

--- a/docs/reference-config-guide-v2.md
+++ b/docs/reference-config-guide-v2.md
@@ -148,7 +148,7 @@ inclusion/exclusion of content. The following types of user variation are expect
 
 GO templating allows use of custom and built in functions to allow complex use cases. In this version all Go built-in
 functions are supported along with the functions in the Sprig library. Also this version follows the Helm templating
-behavior and supports all custom functions that are used in helm (example: toYaml).
+behavior and supports several Helm-style helper functions (e.g. toYaml, toJson, fromYaml, fromJson, include).
 
 ```yaml
 apiVersion: v1
@@ -251,6 +251,40 @@ Returns the matching object if there is exactly one.  The `$apiVersion` and
 `$kind` arguments are required.  Both `$namespace` and `$name` can be blank or
 have the value `*` to match any namespace or name.  If multiple objects are
 matched, this returns `nil`.
+
+#### include
+
+Execute a named template and return its output as a string. This matches
+Helm's `include` function and is the primary way to use reusable template
+snippets defined with `{{define}}` when you need to post-process the output
+(e.g. with `indent` or `nindent`).
+
+Unlike Go's built-in `{{template}}` action which writes directly to the output
+stream, `include` returns a string that can be piped through other functions.
+
+Usage:
+
+First, define a reusable template (typically in a `_helpers.tpl` file listed
+in `templateFunctionFiles`):
+
+```yaml
+{{- define "mychart.labels" -}}
+app: my-app
+chart: my-chart
+{{- end -}}
+```
+
+Then use `include` in your templates:
+
+```yaml
+metadata:
+  labels:
+{{ include "mychart.labels" . | indent 4 }}
+```
+
+The first argument is the template name, and the second is the data to pass
+(typically `.` for the current context). A recursion guard prevents infinite
+loops if a template includes itself.
 
 #### doNotMatch
 

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -447,6 +447,8 @@ func TestCompareRun(t *testing.T) {
 			withUserConfig(userConfigFileName),
 		defaultTest("Ref With Template Functions Renders As Expected").
 			withModes([]Mode{{Live, LocalRef}, {Local, LocalRef}, {Local, URL}}),
+		defaultTest("Include Function").
+			withModes([]Mode{{Live, LocalRef}, {Local, LocalRef}}),
 		defaultTest("YAML Output").
 			withRealHash().
 			withOutputFormat(Yaml).

--- a/pkg/compare/funcmap.go
+++ b/pkg/compare/funcmap.go
@@ -24,6 +24,11 @@ var FuncHelp = make(map[string]string)
 
 const SprigImportFlag = `<<sprig>>`
 
+// recursionMaxNums is the maximum number of times a template may be
+// recursively included before we assume an infinite loop and bail out.
+// This matches Helm's recursion limit.
+const recursionMaxNums = 1000
+
 // FuncMap returns a mapping of all of the functions that Engine has.
 //
 // Because some functions are late-bound (e.g. contain context-sensitive
@@ -32,11 +37,11 @@ const SprigImportFlag = `<<sprig>>`
 //
 // Known late-bound functions:
 //
-//   - "include"
-//   - "tpl"
+//   - "include": executes a named template and returns its output as a string.
 //
-// These are late-bound in Engine.Render().  The
-// version included in the FuncMap is a placeholder.
+// These are late-bound after template parsing via InitInclude.
+// The version included in the FuncMap is a placeholder that will
+// return an error if called before binding.
 func FuncMap() template.FuncMap {
 	f := sprig.TxtFuncMap()
 	delete(f, "env")
@@ -46,6 +51,13 @@ func FuncMap() template.FuncMap {
 	for key := range f {
 		FuncHelp[key] = SprigImportFlag
 	}
+
+	// Add a placeholder for the late-bound "include" function.
+	// The real implementation is injected after template parsing via InitInclude.
+	f["include"] = func(name string, data any) (string, error) {
+		return "", fmt.Errorf("include is not yet bound to a template; this is a placeholder")
+	}
+	FuncHelp["include"] = "Execute a named template and return its output as a string (like Helm's include)"
 
 	// Add some extra functionality
 	extra := map[string]struct {
@@ -289,4 +301,37 @@ func (e DoNotMatch) Error() string {
 
 func doNotMatch(reason string) (string, error) {
 	return "", &DoNotMatch{Reason: reason}
+}
+
+// includeFun returns a function that executes a named template and returns
+// its output as a string. This matches Helm's include semantics.
+// It includes a recursion guard to prevent infinite loops.
+func includeFun(t *template.Template, includedNames map[string]int) func(string, any) (string, error) {
+	return func(name string, data any) (string, error) {
+		var buf strings.Builder
+		if v, ok := includedNames[name]; ok {
+			if v > recursionMaxNums {
+				return "", fmt.Errorf(
+					"rendering template has a nested reference name: %s: unable to execute template",
+					name)
+			}
+			includedNames[name]++
+		} else {
+			includedNames[name] = 1
+		}
+		err := t.ExecuteTemplate(&buf, name, data)
+		includedNames[name]--
+		return buf.String(), err
+	}
+}
+
+// InitInclude binds the late-bound "include" template function to a parsed
+// template. This must be called after template parsing but before execution.
+// It replaces the placeholder include function with a real implementation
+// that can execute named sub-templates.
+func InitInclude(t *template.Template) {
+	includedNames := make(map[string]int)
+	t.Funcs(template.FuncMap{
+		"include": includeFun(t, includedNames),
+	})
 }

--- a/pkg/compare/funcmap_include_test.go
+++ b/pkg/compare/funcmap_include_test.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package compare
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func TestIncludeFun(t *testing.T) {
+	tests := []struct {
+		name        string
+		templateStr string
+		expectOut   string
+		expectErr   string
+	}{
+		{
+			name:        "basic include",
+			templateStr: `{{- define "greeting" -}}hello world{{- end -}}{{ include "greeting" . }}`,
+			expectOut:   "hello world",
+		},
+		{
+			name:        "include with data",
+			templateStr: `{{- define "greet" -}}hello {{ .name }}{{- end -}}{{ include "greet" . }}`,
+			expectOut:   "hello test-user",
+		},
+		{
+			name:        "include piped to upper",
+			templateStr: `{{- define "msg" -}}hello{{- end -}}{{ include "msg" . | upper }}`,
+			expectOut:   "HELLO",
+		},
+		{
+			name:        "include piped to indent",
+			templateStr: `{{- define "block" -}}line1` + "\n" + `line2{{- end -}}{{ include "block" . | indent 2 }}`,
+			expectOut:   "  line1\n  line2",
+		},
+		{
+			name:        "nested include",
+			templateStr: `{{- define "inner" -}}inner{{- end -}}{{- define "outer" -}}[{{ include "inner" . }}]{{- end -}}{{ include "outer" . }}`,
+			expectOut:   "[inner]",
+		},
+		{
+			name:        "include non-existent template returns error",
+			templateStr: `{{ include "does-not-exist" . }}`,
+			expectErr:   "does-not-exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl := template.New("test").Funcs(FuncMap())
+			tmpl, err := tmpl.Parse(tt.templateStr)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			InitInclude(tmpl)
+
+			data := map[string]any{"name": "test-user"}
+			var buf strings.Builder
+			err = tmpl.Execute(&buf, data)
+			if tt.expectErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.expectErr)
+				}
+				if !strings.Contains(err.Error(), tt.expectErr) {
+					t.Fatalf("expected error containing %q, got: %v", tt.expectErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := buf.String(); got != tt.expectOut {
+				t.Errorf("output mismatch:\n  got:  %q\n  want: %q", got, tt.expectOut)
+			}
+		})
+	}
+}
+
+func TestIncludeRecursionGuard(t *testing.T) {
+	// A template that includes itself should hit the recursion limit
+	tmpl := template.New("test").Funcs(FuncMap())
+	tmpl, err := tmpl.Parse(`{{- define "loop" -}}{{ include "loop" . }}{{- end -}}{{ include "loop" . }}`)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	InitInclude(tmpl)
+
+	var buf strings.Builder
+	err = tmpl.Execute(&buf, nil)
+	if err == nil {
+		t.Fatal("expected recursion error, got nil")
+	}
+	if !strings.Contains(err.Error(), "nested reference") {
+		t.Fatalf("expected recursion error, got: %v", err)
+	}
+}

--- a/pkg/compare/parsing.go
+++ b/pkg/compare/parsing.go
@@ -154,6 +154,7 @@ func parseTemplatesCommon[T parsableTemplate](templates []T, functionFiles []str
 				continue
 			}
 		}
+		InitInclude(parsedTemp)
 		temp.setTemplate(parsedTemp)
 		temp.prepareForExec()
 		klog.V(1).Infof("Pre-processing template %s with empty data", temp.GetPath())

--- a/pkg/compare/testdata/IncludeFunction/liveout.golden
+++ b/pkg/compare/testdata/IncludeFunction/liveout.golden
@@ -1,0 +1,6 @@
+Summary
+CRs with diffs: 0/1
+No validation issues with the cluster
+No CRs are unmatched to reference CRs
+Metadata Hash: $METADATA_HASH$
+No patched CRs

--- a/pkg/compare/testdata/IncludeFunction/localout.golden
+++ b/pkg/compare/testdata/IncludeFunction/localout.golden
@@ -1,0 +1,6 @@
+Summary
+CRs with diffs: 0/1
+No validation issues with the cluster
+No CRs are unmatched to reference CRs
+Metadata Hash: $METADATA_HASH$
+No patched CRs

--- a/pkg/compare/testdata/IncludeFunction/reference/_helpers.tpl
+++ b/pkg/compare/testdata/IncludeFunction/reference/_helpers.tpl
@@ -1,0 +1,4 @@
+{{- define "mychart.labels" -}}
+app: my-app
+chart: my-chart
+{{- end -}}

--- a/pkg/compare/testdata/IncludeFunction/reference/cm.yaml
+++ b/pkg/compare/testdata/IncludeFunction/reference/cm.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+{{ include "mychart.labels" . | indent 4 }}
+  name: my-configmap
+  namespace: default

--- a/pkg/compare/testdata/IncludeFunction/reference/metadata.yaml
+++ b/pkg/compare/testdata/IncludeFunction/reference/metadata.yaml
@@ -1,0 +1,10 @@
+parts:
+  - name: ExamplePart
+    components:
+      - name: IncludeTest
+        type: Required
+        requiredTemplates:
+          - path: cm.yaml
+
+templateFunctionFiles:
+  - _helpers.tpl

--- a/pkg/compare/testdata/IncludeFunction/resources/cm.yaml
+++ b/pkg/compare/testdata/IncludeFunction/resources/cm.yaml
@@ -1,0 +1,8 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  labels:
+    app: my-app
+    chart: my-chart
+  name: my-configmap
+  namespace: default


### PR DESCRIPTION
## What

Add the `include` template function, matching Helm's semantics. Unlike Go's built-in `{{template}}` action which writes directly to the output, `{{include}}` executes a named template and returns its result as a string. This allows the output to be piped through other template functions like `indent`, `upper`, `nindent`, etc.

## Why

The `include` function is one of the most commonly used Helm template functions. Reference authors coming from Helm expect it to be available, and it enables cleaner template composition — defining reusable snippets (e.g. standard labels, annotations) in `_helpers.tpl` files and including them with post-processing.

Without `include`, authors are limited to Go's `{{template}}` which cannot be piped:
```
{{/* This works but cannot be indented */}}
{{ template "mychart.labels" . }}

{{/* This is what Helm users expect */}}
{{ include "mychart.labels" . | indent 4 }}
```

## How

The implementation follows the same pattern Helm uses in `pkg/engine/engine.go`:

- A **placeholder** `include` is registered in `FuncMap()` so templates can parse without error
- After parsing, `InitInclude()` **late-binds** the real implementation as a closure over the parsed `*template.Template`, enabling it to call `ExecuteTemplate()`
- A **recursion guard** (max 1000 depth, matching Helm) prevents infinite loops from self-including templates

The function was not imported directly from Helm's engine package because that would pull in the entire chart rendering pipeline (chart loading, Kubernetes client, values handling, etc.) as a dependency. The actual `include` implementation is ~25 lines.

## Testing

- **Unit tests** (`funcmap_include_test.go`): basic include, data passing, piping through `upper`/`indent`, nested includes, missing template error, recursion guard
- **Integration test** (`TestCompareRun/Include_Function`): end-to-end test with a `_helpers.tpl` defining labels and a ConfigMap template using `{{ include "mychart.labels" . | indent 4 }}`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Helm-style `include` support for templates, enabling named partial reuse, passing data context, and using included output with built-in template functions.
  - Added protection against infinite self-referential includes via an enforced recursion limit.
  - Missing included templates now surface clear execution errors.
- **Tests**
  - Expanded coverage for basic, nested, formatted/piped includes, missing-template errors, and recursion-guard behavior, including updated fixtures.
- **Documentation**
  - Updated the config guide to document `include`, including usage examples and the recursion-guard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->