### PR TITLE
build: Bump GOLANG_CROSS_VERSION to v1.26.5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Agent / Developer Guidelines
+
+This file contains internal knowledge, gotchas, and reminders for AI agents
+and developers working on this repository.
+
+## Bumping Go Versions
+
+When you upgrade the Go version (e.g., in `go.mod`), you **must** also update
+the `GOLANG_CROSS_VERSION` variable in the `Makefile`.
+
+**Why?**
+The repository uses the `ghcr.io/goreleaser/goreleaser-cross` Docker image
+to compile cross-platform binaries. The tag of this image corresponds to the
+bundled Go version. If `go.mod` specifies a newer Go version than what is set
+in `GOLANG_CROSS_VERSION`, CI checks (like CodeRabbit) and the release builds
+will fail.
+
+**Steps:**
+
+1. Update the `go` directive in `go.mod`.
+2. Find the corresponding release of
+   [goreleaser-cross](https://github.com/goreleaser/goreleaser-cross/releases)
+   that matches the new Go version.
+3. Update `GOLANG_CROSS_VERSION ?= vX.Y.Z` in the `Makefile`.
+
+## Committing
+
+Before submitting a pull request, ensure that your code passes all locally
+available verification checks. Specifically:
+
+* `make test` or `make test-all`
+* `make golangci-lint`
+
+There is also a `make markdownlint` target to test Markdown files, but this
+requires `docker` or `podman` installed locally.

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 IMAGE_NAME=kube-compare
 
 PACKAGE_NAME          := github.com/openshift/kube-compare
-GOLANG_CROSS_VERSION  ?= v1.24.0
+GOLANG_CROSS_VERSION  ?= v1.26.5
 
 # Auto-detect host OS and architecture if not explicitly set
 HOST_OS := $(shell go env GOOS)


### PR DESCRIPTION
Assisted-by: Gemini 3.1 Pro Preview and pi.dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Go release build environment to version 1.26.5.
  - Improved project guidance for keeping Go versions synchronized across release and CI configurations.
  - Added verification steps to help maintain consistent release tooling and configuration.
  - Documented optional Markdown linting requirements for Docker and Podman-based workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->